### PR TITLE
fix: filter expired available coupons and remind overdue takers

### DIFF
--- a/src/CouponHubBot/Services/BotService.fs
+++ b/src/CouponHubBot/Services/BotService.fs
@@ -114,10 +114,6 @@ type BotService(
             with _ -> None
         else None
 
-    let formatCouponLine (c: Coupon) =
-        let d = c.expires_at.ToString("dd.MM.yyyy")
-        $"{c.id}. {formatCouponValue c}, истекает {d}"
-
     let formatAvailableCouponLine (idx: int) (c: Coupon) =
         let d = c.expires_at.ToString("dd.MM.yyyy")
         $"{idx}. {formatCouponValue c}, истекает {d}"
@@ -247,7 +243,7 @@ type BotService(
                 do! botClient.SendPhoto(
                         ChatId chatId,
                         InputFileId coupon.photo_file_id,
-                        caption = $"Ты взял купон {couponId}: {formatCouponValue coupon}, истекает {d}",
+                        caption = $"Ты взял(а) купон {couponId}: {formatCouponValue coupon}, истекает {d}",
                         replyMarkup = singleTakenKeyboard coupon)
                     |> taskIgnore
         }
@@ -256,7 +252,7 @@ type BotService(
         task {
             let! updated = db.MarkUsed(couponId, user.id)
             if updated then
-                do! sendText chatId $"Отметил купон {couponId} как использованный."
+                do! sendText chatId $"Отметил(а) купон {couponId} как использованный."
             else
                 do! sendText chatId $"Не получилось отметить купон {couponId}. Убедись что он взят тобой."
             return updated
@@ -266,7 +262,7 @@ type BotService(
         task {
             let! updated = db.ReturnToAvailable(couponId, user.id)
             if updated then
-                do! sendText chatId $"Вернул купон {couponId} в доступные."
+                do! sendText chatId $"Вернул(а) купон {couponId} в доступные."
             else
                 do! sendText chatId $"Не получилось вернуть купон {couponId}. Убедись что он взят тобой."
             return updated
@@ -356,7 +352,7 @@ type BotService(
                     let v = coupon.value.ToString("0.##")
                     let mc = coupon.min_check.ToString("0.##")
                     let d = coupon.expires_at.ToString("dd.MM.yyyy")
-                    do! sendText chatId $"Добавил купон {coupon.id}: {v} EUR из {mc} EUR, истекает {d}"
+                    do! sendText chatId $"Добавил купон ID:{coupon.id}: {v} EUR из {mc} EUR, истекает {d}"
                 | _ ->
                     do! sendText chatId "Не понял discount/min_check/date. Пример: /add 10 50 2026-01-25 (или /add 10 50 25.01.2026)"
             else
@@ -579,7 +575,7 @@ type BotService(
                                 let v = coupon.value.ToString("0.##")
                                 let mc = coupon.min_check.ToString("0.##")
                                 let d = coupon.expires_at.ToString("dd.MM.yyyy")
-                                do! sendText cq.Message.Chat.Id $"Добавил купон {coupon.id}: {v} EUR из {mc} EUR, истекает {d}"
+                                do! sendText cq.Message.Chat.Id $"Добавил купон ID:{coupon.id}: {v} EUR из {mc} EUR, истекает {d}"
                             else
                                 do! sendText cq.Message.Chat.Id "Не хватает данных для добавления. Начни заново: /add"
                         | "addflow:cancel" ->

--- a/src/CouponHubBot/Services/ReminderService.fs
+++ b/src/CouponHubBot/Services/ReminderService.fs
@@ -71,6 +71,19 @@ type ReminderService(
                 do! botClient.SendMessage(ChatId botConfig.CommunityChatId, text) :> Task
                 anySent <- true
 
+            // DM reminder: user has taken coupons older than 1 day and forgot to mark used/return.
+            // One message per user even if multiple overdue coupons.
+            let! overdueUsers = db.GetUsersWithOverdueTakenCoupons(nowUtc, TimeSpan.FromDays(1.0))
+            for r in overdueUsers do
+                try
+                    let suffix = if r.overdue_count = 1 then "" else "ов"
+                    let text =
+                        $"Напоминание: у тебя есть {r.overdue_count} купон{suffix}, взятый более 1 дня назад и всё ещё не отмеченный.\nОткрой /my и нажми «Использован» или «Вернуть»."
+                    do! botClient.SendMessage(ChatId r.user_id, text) :> Task
+                    anySent <- true
+                with ex ->
+                    logger.LogWarning(ex, "Failed to send overdue-taken reminder to {UserId}", r.user_id)
+
             return anySent
         }
 

--- a/tests/CouponHubBot.Tests/Program.fs
+++ b/tests/CouponHubBot.Tests/Program.fs
@@ -1,6 +1,7 @@
 open Xunit
 open Xunit.Extensions.AssemblyFixture
 
+[<assembly: CollectionBehavior(DisableTestParallelization = true)>]
 [<assembly: TestFramework(AssemblyFixtureFramework.TypeName, AssemblyFixtureFramework.AssemblyName)>]
 do ()
 


### PR DESCRIPTION
- Exclude expired coupons from available list and prevent taking expired coupons

- Send daily DM reminder to users with taken coupons older than 1 day (one per user)

- Stabilize tests (disable parallelization) and add coverage for new rules