### PR TITLE
fix: show Dublin-local today in /my and add weekday to expiry dates

### DIFF
--- a/src/CouponHubBot/Services/NotificationService.fs
+++ b/src/CouponHubBot/Services/NotificationService.fs
@@ -23,7 +23,7 @@ type TelegramNotificationService(
     let fmtCoupon (c: Coupon) =
         let v = c.value.ToString("0.##")
         let mc = c.min_check.ToString("0.##")
-        let d = c.expires_at.ToString("dd.MM.yyyy")
+        let d = Utils.DateFormatting.formatDateNoYearWithDow c.expires_at
         v, mc, d
 
     let sendToGroup (text: string) =

--- a/tests/CouponHubBot.Tests/CouponTests.fs
+++ b/tests/CouponHubBot.Tests/CouponTests.fs
@@ -1092,7 +1092,7 @@ VALUES (@owner_id, @photo_file_id, @value, @min_check, @expires_at::date, 'avail
                 Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
 
                 let! calls = fixture.GetFakeCalls("sendMessage")
-                let expectedStr = expected.ToString("dd.MM.yyyy")
+                let expectedStr = expected.ToString("d MMMM, dddd", System.Globalization.CultureInfo("ru-RU"))
                 Assert.True(findCallWithText calls user.Id expectedStr, $"Expected DM to include formatted date {expectedStr} for input '{dateStr}'")
 
                 let! couponId = getLatestCouponId ()


### PR DESCRIPTION
- Format all user-facing expiry dates as "d MMMM, dddd" (ru-RU) without year
- Prepend /my output with current date based on Europe/Dublin (from TimeProvider UTC)