### PR TITLE
docs: instruct Copilot agent to build only, not run Docker tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,8 @@ Read [AGENTS.md](../AGENTS.md) first — it is the table of contents for all pro
 
 1. Create a feature branch from `main`
 2. Make changes following the patterns in `docs/`
-3. Run `dotnet test -c Release` to verify (requires Docker)
-4. If tests fail, check `test-artifacts/` for container logs
+3. Run `dotnet build -c Release` to verify compilation
+4. **Do NOT run `dotnet test`** — Docker-based E2E tests will timeout in the agent environment. The PR CI workflow (`build.yml`) runs tests automatically on push.
 5. Create a PR referencing the issue number
 
 ## Debugging Deployment Failures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,10 @@ The agent has VPN access to `*.internal` hosts (established by `copilot-setup-st
 
 1. Read relevant `docs/` file for the domain you're changing
 2. Write/update E2E tests in `tests/CouponHubBot.Tests/`
-3. Run `dotnet test -c Release` locally (requires Docker)
-4. If adding a new table, add migration in `src/migrations/` with GRANT
-5. Update the relevant `docs/` file if behavior changed
+3. Run `dotnet build -c Release` to verify compilation
+4. **Do NOT run `dotnet test`** — Docker-based E2E tests will timeout in the agent environment. The PR CI workflow (`build.yml`) runs tests automatically on proper runners.
+5. If adding a new table, add migration in `src/migrations/` with GRANT
+6. Update the relevant `docs/` file if behavior changed
 
 ## When Debugging a Test Failure
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,10 @@
 # Testing
 
+## ⚠️ Agent Environment
+
+**Copilot coding agent must NOT run `dotnet test`.**
+Docker-based E2E tests require significant resources and will hang/timeout on the agent's GitHub-hosted runner. Use `dotnet build -c Release` to verify compilation only. The PR CI workflow (`build.yml`) runs the full test suite on proper runners automatically.
+
 ## Docker Suite (Testcontainers)
 
 E2E tests live in `tests/CouponHubBot.Tests/`. They use Testcontainers to spin up:


### PR DESCRIPTION
Docker-based E2E tests (Testcontainers) hang/timeout on the Copilot agent's GitHub-hosted runner due to resource constraints.

**Changes:**
- `AGENTS.md` — "When Adding a New Feature" now says `dotnet build -c Release` with explicit warning against `dotnet test`
- `.github/copilot-instructions.md` — Development Workflow updated to build-only
- `docs/TESTING.md` — Added "⚠️ Agent Environment" section at the top

The PR CI workflow (`build.yml`) continues to run the full test suite on proper runners automatically.