### PR TITLE
fix: inject code review rules into copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,3 +29,60 @@ Telegram bot for collaborative coupon management in a private community. Written
 - Database role: `coupon_hub_bot_service`. Always add `GRANT` in migrations for new tables.
 - F# compilation order matters — new `.fs` files must be added to `.fsproj` in the correct position.
 - `TreatWarningsAsErrors` is enabled — all warnings are errors.
+
+---
+
+## Code Review Rules
+
+When reviewing pull requests, check the following project-specific conventions. Prioritize bugs, security issues, missing validation, and convention violations over style.
+
+### F# Conventions
+
+- Always use `task { }` CE for async, never `async { }`. Use `let!` for awaiting, never `.Result` or `.Wait()` — they cause deadlocks in ASP.NET Core.
+- All database-mapped records must have `[<CLIMutable>]` attribute for Dapper compatibility.
+- Use `[<RequireQualifiedAccess>]` on discriminated unions to prevent name collisions.
+- Nullable database columns use `string | null` annotation, not `string option` (for Dapper compatibility).
+- Prefer exhaustive `match` expressions over nested `if/else`.
+- New `.fs` files must be added to `.fsproj` in correct compilation order — F# compiles files sequentially and a file can only reference types defined in files listed above it.
+
+### Telegram Bot Patterns
+
+- Callback data uses colon-separated format: `"action:param1:param2"`. Always validate callback data parameters — users can craft arbitrary callback data.
+- Always answer callback queries to dismiss the Telegram loading indicator.
+- Verify community membership before processing coupon operations.
+- All button labels and user-facing messages must be in Russian (Cyrillic).
+- Wizard flows persist state in `PendingAddFlow` table. Each stage must validate the previous stage's data before proceeding.
+
+### Database Conventions
+
+- Migration files follow naming: `V{N}__{description}.sql` (sequential number, double underscore, snake_case).
+- New tables and sequences must include `GRANT` for the `coupon_hub_bot_service` role.
+- Use parameterized SQL queries only — never string-interpolate user input into SQL.
+
+### Cyrillic / Russian Text
+
+- All user-facing text must be in Russian.
+- Never compare raw JSON strings containing Cyrillic — always parse with `JsonDocument` or `JsonSerializer` first, then compare parsed values.
+- In tests, use `findCallWithText` helpers from `FakeCallHelpers.fs` which handle JSON parsing correctly.
+
+```fsharp
+// Correct — parsed comparison
+Assert.True(findCallWithText calls 200L "Добавил купон", "Expected confirmation message")
+
+// Wrong — raw string comparison will fail on Cyrillic
+Assert.Contains("\"text\":\"Добавил купон\"", responseBody)
+```
+
+### Testing Patterns
+
+- Tests use xUnit v3 with assembly fixtures and Testcontainers (PostgreSQL, Flyway, FakeTgApi, bot).
+- Use `findCallWithText` to assert the bot sent a specific message to a specific chat.
+- Use `findCallWithAnyText` when checking for any message to a chat without specific text matching.
+- Time-dependent tests must use `BOT_FIXED_UTC_NOW` environment variable for deterministic behavior.
+
+### Security
+
+- Never commit secrets, tokens, or API keys — use environment variables.
+- Validate all Telegram callback data — it can be crafted by malicious clients.
+- Use parameterized SQL — never interpolate user input into queries.
+- Verify community membership before allowing access to coupon operations.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -5,91 +5,57 @@ excludeAgent: "coding-agent"
 
 # Code Review Instructions for coupon-hub-bot
 
-Review code changes against conventions and patterns established in this F# / .NET 10 Telegram bot codebase.
+Review code changes against conventions and patterns in this F# / .NET 10 Telegram bot codebase. Prioritize bugs, security issues, missing validation, and convention violations over style.
 
-**Reviewer mindset:** Be polite but skeptical. Your job is to help speed the review process for maintainers — find problems the PR author may have missed and question whether the approach is correct. Treat the PR description and linked issues as claims to verify, not facts to accept.
+## F# Conventions
 
-## Review Guidelines
+- Always use `task { }` CE for async, never `async { }`. Use `let!` for awaiting, never `.Result` or `.Wait()` — they cause deadlocks in ASP.NET Core.
+- All database-mapped records must have `[<CLIMutable>]` attribute for Dapper compatibility.
+- Use `[<RequireQualifiedAccess>]` on discriminated unions to prevent name collisions.
+- Nullable database columns use `string | null` annotation, not `string option` (for Dapper compatibility).
+- Prefer exhaustive `match` expressions over nested `if/else`.
+- New `.fs` files must be added to `.fsproj` in correct compilation order — F# compiles files sequentially and a file can only reference types defined in files listed above it.
 
-1. **Read the full source files** for every changed file (not just diff hunks) to understand invariants and state flow.
-2. **Focus on what matters.** Prioritize bugs, incorrect state transitions, race conditions, missing validation, and convention violations. Do not comment on trivial style.
-3. **Be specific and actionable.** Every comment should tell the author exactly what to change and why.
-4. **Flag severity clearly:**
-   - ❌ **error** — Must fix before merge. Bugs, security issues, convention violations.
-   - ⚠️ **warning** — Should fix. Missing validation, inconsistency with patterns.
-   - 💡 **suggestion** — Consider changing. Minor improvements.
-   - ✅ **verified** — Confirmed correct. Use to show important aspects were checked.
-5. **Don't pile on.** If the same issue appears many times, flag it once with a note listing all affected files.
-6. **Don't flag what CI catches.** Assume `dotnet build -c Release` with `TreatWarningsAsErrors` and tests run separately.
-7. **Verdict must match findings.** If you have ⚠️ findings, don't say LGTM. If uncertain, use "Needs Human Review."
+## Telegram Bot Patterns
 
----
+- Callback data uses colon-separated format: `"action:param1:param2"`. Always validate callback data parameters — users can craft arbitrary callback data.
+- Always answer callback queries to dismiss the Telegram loading indicator.
+- Verify community membership before processing coupon operations.
+- All button labels and user-facing messages must be in Russian (Cyrillic).
+- Wizard flows persist state in `PendingAddFlow` table. Each stage must validate the previous stage's data before proceeding.
 
-## F# Conventions to Check
+## Database Conventions
 
-- **Always `task { }` CE for async**, never `async { }`. Use `let!` for awaiting, never `.Result` or `.Wait()`.
-- **`[<CLIMutable>]`** on all database-mapped records (for Dapper).
-- **`[<RequireQualifiedAccess>]`** on discriminated unions.
-- **Nullable DB columns** use `string | null` annotation, not `string option`.
-- **Exhaustive pattern matching** — avoid nested `if/else`, prefer `match`.
-- **New `.fs` files** must be added to `.fsproj` in the correct compilation order.
-- **No `.Result`, `.Wait()`, `Async.RunSynchronously`** in the request pipeline — causes deadlocks.
+- Migration files follow naming: `V{N}__{description}.sql` (sequential number, double underscore, snake_case).
+- New tables and sequences must include `GRANT` for the `coupon_hub_bot_service` role.
+- Use parameterized SQL queries only — never string-interpolate user input into SQL.
 
-## Telegram Bot Patterns to Check
+## Cyrillic / Russian Text
 
-- **Callback data format**: `"action:param1:param2"` (colon-separated). Always validate — users can craft arbitrary callback data.
-- **Always answer callback queries** to dismiss the loading indicator.
-- **Verify community membership** before processing user actions.
-- **Button labels must be in Russian** (Cyrillic).
-- **Wizard flows** use `PendingAddFlow` table for state. Each stage validates the previous stage's data.
+- All user-facing text must be in Russian.
+- Never compare raw JSON strings containing Cyrillic — always parse with `JsonDocument` or `JsonSerializer` first, then compare parsed values.
+- In tests, use `findCallWithText` helpers from `FakeCallHelpers.fs` which handle JSON parsing correctly.
 
-## Database Conventions to Check
+```fsharp
+// Correct — parsed comparison
+Assert.True(findCallWithText calls 200L "Добавил купон", "Expected confirmation message")
 
-- **Migration naming**: `V{N}__{description}.sql` (sequential number, double underscore, snake_case).
-- **Always `GRANT`** for `coupon_hub_bot_service` role on new tables/sequences.
-- **Parameterized SQL only** — never string-interpolate user input into queries.
-- **`QuerySingle`, `QuerySingleOrDefault`, `Execute`** — correct cardinality for the query.
+// Wrong — raw string comparison will fail on Cyrillic
+Assert.Contains("\"text\":\"Добавил купон\"", responseBody)
+```
 
-## Cyrillic / Russian Text Rules
+## Testing Patterns
 
-- **All user-facing text must be in Russian.**
-- **Never compare raw JSON strings containing Cyrillic.** Always parse with `JsonDocument` or `JsonSerializer` first.
-- **In tests, use `findCallWithText` helpers** from `FakeCallHelpers.fs`.
-
-## Testing Patterns to Check
-
-- Tests use **xUnit v3 with assembly fixtures** and Testcontainers (PostgreSQL, Flyway, FakeTgApi, bot).
-- Use **`findCallWithText`** for asserting bot messages, **`findCallWithAnyText`** for any-message checks.
-- Tests that depend on time must use **`BOT_FIXED_UTC_NOW`** for deterministic behavior.
+- Tests use xUnit v3 with assembly fixtures and Testcontainers (PostgreSQL, Flyway, FakeTgApi, bot).
+- Use `findCallWithText` to assert the bot sent a specific message to a specific chat.
+- Use `findCallWithAnyText` when checking for any message to a chat without specific text matching.
+- Time-dependent tests must use `BOT_FIXED_UTC_NOW` environment variable for deterministic behavior.
 
 ## Security
 
-- Never commit secrets, tokens, or API keys.
-- Validate all Telegram callback data.
-- Use parameterized SQL.
-- Verify community membership before coupon operations.
+- Never commit secrets, tokens, or API keys — use environment variables.
+- Validate all Telegram callback data — it can be crafted by malicious clients.
+- Use parameterized SQL — never interpolate user input into queries.
+- Verify community membership before allowing access to coupon operations.
 
----
-
-## Review Output Format
-
-```
-## 🤖 Copilot Code Review — PR #<number>
-
-### Holistic Assessment
-
-**Motivation**: <1-2 sentences on whether the PR is justified>
-
-**Approach**: <1-2 sentences on whether the approach is right>
-
-**Summary**: <✅ LGTM / ⚠️ Needs Human Review / ⚠️ Needs Changes / ❌ Reject>. <2-3 sentence summary.>
-
----
-
-### Detailed Findings
-
-#### ✅/⚠️/❌/💡 <Category> — <Brief description>
-
-<Explanation with specifics. Reference code, line numbers, files.>
-```
 


### PR DESCRIPTION
## Problem

Path-specific instructions (\.github/instructions/*.instructions.md\) appear to not be read by Copilot code review at all ([community discussion](https://github.com/orgs/community/discussions/184036)). The \copilot-instructions.md\ repo-wide file IS confirmed to be loaded.

## Approach

Inject the code review domain rules directly into \copilot-instructions.md\ under a separate \## Code Review Rules\ section. This way code review gets the rules via the one file it definitely reads.

The \code-review.instructions.md\ file is kept as a fallback — if GitHub fixes path-specific instruction loading, both files will contribute.

## Changes

- **\copilot-instructions.md\**: Added \## Code Review Rules\ section with all domain-specific review rules (F# conventions, Telegram patterns, DB conventions, Cyrillic handling, testing, security)
- **\code-review.instructions.md\**: Simplified — removed unsupported format/emoji instructions per [GitHub docs](https://docs.github.com/en/copilot/tutorials/use-custom-instructions#unsupported-instruction-types)

## Verification

After merging, re-request Copilot review on PR #71 to test.