### PR TITLE
Fix connectivity check: discard curl response body

### DIFF
--- a/scripts/gather-metrics.sh
+++ b/scripts/gather-metrics.sh
@@ -39,8 +39,8 @@ prom_value() {
 
 log "Verifying connectivity..."
 
-PROM_OK=$(curl -sf "${PROMETHEUS_URL}/-/healthy" 2>/dev/null && echo "yes" || echo "no")
-LOKI_OK=$(curl -sf "${LOKI_URL}/ready" 2>/dev/null && echo "yes" || echo "no")
+PROM_OK=$(curl -sf -o /dev/null "${PROMETHEUS_URL}/-/healthy" 2>/dev/null && echo "yes" || echo "no")
+LOKI_OK=$(curl -sf -o /dev/null "${LOKI_URL}/ready" 2>/dev/null && echo "yes" || echo "no")
 ARGO_OK=$(curl -sf "${ARGOCD_URL}/api/v1/applications" -H "${AUTH_HEADER}" -o /dev/null 2>/dev/null && echo "yes" || echo "no")
 
 log "Prometheus: ${PROM_OK}, Loki: ${LOKI_OK}, ArgoCD: ${ARGO_OK}"


### PR DESCRIPTION
## Problem

In issue #75, the Prometheus connectivity row rendered as:

| Prometheus | Prometheus Server is Healthy. yes |

The health endpoint returns body text, which curl prints to stdout before echo yes appends. ArgoCD check already used -o /dev/null but Prometheus and Loki didn't.

## Fix

Add -o /dev/null to Prometheus and Loki connectivity checks to discard the response body, matching the ArgoCD check pattern.

Note: this script runs on Ubuntu (GitHub Actions), not Windows.