### PR TITLE
Fix Deployed Image and remove Process Up metric

### DIFF
--- a/scripts/gather-metrics.sh
+++ b/scripts/gather-metrics.sh
@@ -169,8 +169,8 @@ ARGO_RESPONSE=$(curl -sf "${ARGOCD_URL}/api/v1/applications/${APP_NAME}" \
 
 SYNC_STATUS=$(echo "$ARGO_RESPONSE" | jq -r '.status.sync.status // "Unknown"')
 HEALTH_STATUS=$(echo "$ARGO_RESPONSE" | jq -r '.status.health.status // "Unknown"')
-DEPLOYED_IMAGES=$(echo "$ARGO_RESPONSE" | jq -r '.status.summary.images // [] | .[]' 2>/dev/null \
-    | sed 's/:\([a-f0-9]\{12\}\)[a-f0-9]\{28,\}$/:\1…/' || true)
+DEPLOYED_IMAGES=$(echo "$ARGO_RESPONSE" | jq -r '.status.summary.images // [] | join(", ")' 2>/dev/null \
+    | sed 's/:\([a-f0-9]\{12\}\)[a-f0-9]\{28,\}/:\1…/g' || true)
 [ -z "$DEPLOYED_IMAGES" ] && DEPLOYED_IMAGES="Unknown"
 ARGO_CONDITIONS=$(echo "$ARGO_RESPONSE" | jq -r '[.status.conditions[]? | "\(.type): \(.message)"] | join("\n")' 2>/dev/null || true)
 [ -z "$ARGO_CONDITIONS" ] && ARGO_CONDITIONS="none"


### PR DESCRIPTION
Fixes two issues from self-assessment #80: (1) Deployed Image showed Unknown due to jq sub() failure - replaced with jq+sed pipeline, (2) Process Up was always N/A because bot uses OTLP push not scrape - removed row, Pod Ready covers availability.