### PR TITLE
Configure gh CLI with PAT for Copilot issue management

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
+
+      - name: Configure GitHub CLI for issue management
+        run: echo "${{ secrets.COPILOT_ASSIGN_PAT }}" | gh auth login --with-token


### PR DESCRIPTION
The Copilot coding agent's built-in platform token can create issues but cannot close or comment on existing ones (see PR #91 summary). This prevents the self-assessment skill from:
- Closing resolved issues (e.g., #82 Loki unreachable)
- Bumping existing issues with comments
- Closing the orchestration issue

**Fix**: Add a step to \copilot-setup-steps.yml\ that logs \gh\ CLI in with \COPILOT_ASSIGN_PAT\ (already available in the \copilot\ environment). This persists to \~/.config/gh/hosts.yml\ so the agent uses the PAT for all \gh\ commands.