### PR TITLE
Fix gh auth login in copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure GitHub CLI for issue management
         run: |
           if [ -n "$PAT" ]; then
-            echo "$PAT" | gh auth login --with-token
+            printf '%s' "$PAT" | gh auth login --with-token
           else
             echo "WARNING: COPILOT_ASSIGN_PAT not available, gh CLI will use default token"
           fi


### PR DESCRIPTION
Fixes the broken `gh auth login` step from PR #94.

Two problems identified:
1. **VPN blocks github.com**: The step ran AFTER `wg-quick up`, but the VPN routes all traffic through the tunnel, blocking `github.com`
2. **Empty secret**: If `COPILOT_ASSIGN_PAT` isn't available in the setup context, the step should gracefully skip

Changes:
- Move `Configure GitHub CLI` step **before** WireGuard VPN setup
- Use env var (`PAT`) instead of inline secret to avoid leaking empty string in logs
- Add non-fatal check: skip with warning if secret is unavailable