### PR TITLE
Add auto-fix workflow for automated issue pickup

### DIFF
--- a/.github/skills/self-assess/SKILL.md
+++ b/.github/skills/self-assess/SKILL.md
@@ -163,7 +163,13 @@ For each finding from Phases 2-3, decide: **create**, **bump**, or **skip**.
    ```
    Also ensure the issue has the `self-assess` label — if not, add it: `gh issue edit NUMBER --add-label "self-assess"`
 3. **ALWAYS use `--label "self-assess"`** when creating issues. Every issue created by self-assessment MUST have this label. No exceptions.
-4. **Create if new**: Use this template for new issues:
+4. **Assign priority and scope labels** on every issue you create or bump:
+   - **Priority** (exactly one): `priority-medium` (bugs, security, performance, significant tech debt), `priority-low` (nice-to-have improvements). **Never use `priority-high`** — that label is reserved for user-reported feedback.
+   - **Scope**: Add `infra` label if the issue cannot be fixed in this repo (e.g., Kubernetes resource limits, AKS config, networking). Infra issues are skipped by the auto-fix workflow.
+   - When bumping, reassess priority — if a `priority-low` issue keeps getting bumped, consider upgrading to `priority-medium`.
+   - Example: `gh issue create --label "self-assess" --label "priority-medium" --title "..."`
+   - Example: `gh issue create --label "self-assess" --label "priority-medium" --label "infra" --title "CPU throttling..."`
+5. **Create if new**: Use this template for new issues:
    ```
    gh issue create \
      --title "Brief descriptive title" \
@@ -184,15 +190,15 @@ For each finding from Phases 2-3, decide: **create**, **bump**, or **skip**.
 
    [Why this matters: reliability, security, performance, maintainability]"
    ```
-5. **Close if resolved**: For each open `self-assess` issue, check if the underlying problem is still present. If it's fixed, close it:
+6. **Close if resolved**: For each open `self-assess` issue, check if the underlying problem is still present. If it's fixed, close it:
    ```
    gh issue close NUMBER \
      --comment "✅ **Resolved** (YYYY-MM-DD self-assessment)
 
    [Explanation of how/when this was fixed]"
    ```
-6. **Never assign**: Do not assign anyone (including Copilot) to backlog issues
-7. **Quality over quantity**: Only create issues for things that genuinely matter:
+7. **Never assign**: Do not assign anyone (including Copilot) to backlog issues
+8. **Quality over quantity**: Only create issues for things that genuinely matter:
    - Bugs or potential bugs
    - Security vulnerabilities
    - Performance problems
@@ -200,7 +206,7 @@ For each finding from Phases 2-3, decide: **create**, **bump**, or **skip**.
    - Significant tech debt
    - Documentation that's actively misleading
    - Infrastructure concerns
-8. **Do NOT create issues for**:
+9. **Do NOT create issues for**:
    - Style preferences or minor formatting
    - Speculative improvements with no clear benefit
    - Things that are working correctly and don't need changes

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,85 @@
+name: Auto-fix Issues
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-fix:
+    runs-on: ubuntu-latest
+    environment: copilot
+    - name: Check for in-flight Copilot session
+      id: mutex
+      env:
+        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      run: |
+        # Draft PRs by Copilot = actively working (excluding daily orchestration PRs)
+        ACTIVE=$(gh pr list \
+          --repo "${{ github.repository }}" \
+          --state open \
+          --limit 200 \
+          --author "app/copilot-swe-agent" \
+          --json number,title,isDraft \
+          --jq '[.[] | select(.isDraft == true) | select(.title | test("Daily self-assessment \\d{4}-\\d{2}-\\d{2}"; "i") | not)] | length')
+
+        echo "Active Copilot sessions: $ACTIVE"
+        if [ "$ACTIVE" -gt 0 ]; then
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Find highest priority issue
+      if: steps.mutex.outputs.skip == 'false'
+      id: pick
+      env:
+        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      run: |
+        # Get all open self-assess issues, exclude orchestration and infra
+        # Priority: priority-high (3) > priority-medium (2) > priority-low/none (1)
+        # Then by bump count (comments), then by age (oldest first)
+        ISSUE=$(gh issue list \
+          --repo "${{ github.repository }}" \
+          --label "self-assess" \
+          --state open \
+          --limit 200 \
+          --json number,title,labels,comments,createdAt,assignees \
+          --jq '
+            [.[]
+              | select(.title | test("Daily self-assessment \\d{4}-\\d{2}-\\d{2}"; "i") | not)
+              | select(.labels | map(.name) | any(. == "infra") | not)
+              | select(.assignees | length == 0)
+              | .priority = (
+                  if (.labels | map(.name) | any(. == "priority-high")) then 3
+                  elif (.labels | map(.name) | any(. == "priority-medium")) then 2
+                  else 1
+                  end)
+            ]
+            | sort_by([-.priority, -.comments, .createdAt])
+            | .[0]
+            | .number // empty')
+
+        if [ -z "$ISSUE" ]; then
+          echo "No issues to pick up."
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "Found issue #$ISSUE"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "issue=$ISSUE" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Assign Copilot to issue
+      if: steps.mutex.outputs.skip == 'false' && steps.pick.outputs.found == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      run: |
+        ISSUE=${{ steps.pick.outputs.issue }}
+        echo "Assigning Copilot to issue #$ISSUE"
+        gh issue edit "$ISSUE" \
+          --repo "${{ github.repository }}" \
+          --add-assignee "copilot" \
+          || echo "WARNING: Failed to assign Copilot to #$ISSUE"

--- a/.github/workflows/self-assess.yml
+++ b/.github/workflows/self-assess.yml
@@ -87,7 +87,7 @@ jobs:
       if: always()
       run: sudo wg-quick down wg0 || true
 
-    - name: Ensure self-assess label exists
+    - name: Ensure labels exist
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
       run: |
@@ -95,6 +95,26 @@ jobs:
           --repo "${{ github.repository }}" \
           --description "Auto-discovered by daily self-assessment workflow" \
           --color "7057ff" \
+          --force
+        gh label create infra \
+          --repo "${{ github.repository }}" \
+          --description "Infrastructure issue — cannot be fixed in this repo" \
+          --color "d4c5f9" \
+          --force
+        gh label create priority-high \
+          --repo "${{ github.repository }}" \
+          --description "Reserved for user-reported high-priority issues (not used by self-assess)" \
+          --color "b60205" \
+          --force
+        gh label create priority-medium \
+          --repo "${{ github.repository }}" \
+          --description "Medium priority" \
+          --color "fbca04" \
+          --force
+        gh label create priority-low \
+          --repo "${{ github.repository }}" \
+          --description "Low priority — nice to have" \
+          --color "0e8a16" \
           --force
 
     - name: Create orchestration issue

--- a/docs/SELF-ASSESSMENT.md
+++ b/docs/SELF-ASSESSMENT.md
@@ -41,10 +41,10 @@ The daily self-assessment workflow acts as an **automated product manager**. It 
 
 | Component | Path | Purpose |
 |-----------|------|---------|
-| Workflow | `.github/workflows/self-assess.yml` | Scheduled trigger, VPN, metrics collection, issue creation |
-| Metrics script | `scripts/gather-metrics.sh` | Queries Prometheus, Loki, ArgoCD; outputs markdown report |
-| Skill | `.github/skills/self-assess/SKILL.md` | Instructions for Copilot on how to analyze and manage backlog |
-| Label | `self-assess` | Applied to all backlog issues created by this flow |
+| Self-assess workflow | `.github/workflows/self-assess.yml` | Daily trigger, VPN, metrics, issue creation |
+| Auto-fix workflow | `.github/workflows/auto-fix.yml` | Hourly pickup, mutex check, Copilot assignment |
+| Metrics script | `scripts/gather-metrics.sh` | Queries Prometheus, Loki, ArgoCD; outputs markdown |
+| Skill | `.github/skills/self-assess/SKILL.md` | Instructions for Copilot analysis and backlog management |
 
 ## Metrics Gathered
 
@@ -67,12 +67,22 @@ The daily self-assessment workflow acts as an **automated product manager**. It 
 - Currently deployed image tag
 - Conditions/warnings
 
+## Labels
+
+| Label | Color | Purpose |
+|-------|-------|---------|
+| `self-assess` | Purple (#7057ff) | Applied to all backlog issues created by self-assessment |
+| `infra` | Light purple (#d4c5f9) | Infrastructure issue — cannot be fixed in this repo, skipped by auto-fix |
+| `priority-high` | Red (#b60205) | Reserved for user-reported feedback (not used by self-assess) |
+| `priority-medium` | Yellow (#fbca04) | Bugs, security, performance, significant tech debt |
+| `priority-low` | Green (#0e8a16) | Nice-to-have improvements |
+
 ## Backlog Management Rules
 
-- **Create**: New issue for a newly discovered problem (labeled `self-assess`)
-- **Bump**: Comment on existing issue if the same problem persists
+- **Create**: New issue for a newly discovered problem (labeled `self-assess` + `priority-medium` or `priority-low` + optional `infra`)
+- **Bump**: Comment on existing issue if the same problem persists; reassess priority (up to `priority-medium` max)
 - **Close**: Close issue if the underlying problem is resolved
-- **Never assign**: Backlog issues are left unassigned — a future companion workflow will pick the most-bumped issue for implementation
+- **Never assign**: Backlog issues are left unassigned — the auto-fix workflow picks them up
 
 ## Issue Lifecycle
 
@@ -112,11 +122,73 @@ The cleanup runs at the start of each workflow invocation, giving Copilot ~24 ho
 
 All secrets are configured in the `copilot` environment.
 
-## Future: Auto-Implementation Companion
+## Auto-Fix Workflow
 
-A planned companion workflow will:
-1. Run daily after self-assessment completes
-2. Query open `self-assess` issues
-3. Rank by number of bump comments (most-bumped = highest priority)
-4. Assign Copilot to the top issue for automatic implementation
-5. This creates a **self-improving codebase** feedback loop
+The auto-fix workflow (`auto-fix.yml`) is the companion to self-assessment. It picks up backlog issues and assigns Copilot to implement fixes automatically.
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  auto-fix.yml (hourly at :17)                                   │
+│                                                                 │
+│  1. Mutex check: any draft PRs by Copilot? (excl. self-assess)  │
+│     → If yes: skip (Copilot is busy)                            │
+│     → If no: proceed                                            │
+│                                                                 │
+│  2. Pick highest priority issue:                                │
+│     - Has label: self-assess                                    │
+│     - NOT orchestration issue (title contains "self-assessment") │
+│     - NOT labeled: infra                                        │
+│     - Sort: priority-high > medium > low > bumps > oldest       │
+│                                                                 │
+│  3. Assign Copilot to the issue                                 │
+│     → Copilot creates branch + PR with the fix                  │
+│     → PR goes through normal review                             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Mutex: One Session at a Time
+
+The workflow ensures only one Copilot coding session runs at a time by checking for open **draft PRs** by `app/copilot-swe-agent`. Draft = Copilot is actively working. Ready-for-review = done (doesn't block).
+
+### Priority Sorting
+
+Auto-fix only considers issues labeled `self-assess`. Issues are picked in this order (equivalent to `ORDER BY priority DESC, comments DESC, created_at ASC`):
+1. `priority-high` labels first (if a user manually adds both `self-assess` and `priority-high`)
+2. `priority-medium` next (most self-assess issues)
+3. `priority-low` / unlabeled last
+4. Within same priority: most comments first (total GitHub comment count is used as a proxy for bump frequency)
+5. Within same comment count: oldest issue first
+
+### Skipped Issues
+
+- **`infra` label**: Infrastructure issues that belong to a different repo (e.g., `my-infra`). These remain in the backlog for human attention.
+- **Orchestration issues**: Title matching "self-assessment YYYY-MM-DD" — these are workflow artifacts, not fixable issues.
+
+### Schedule
+
+- **Cron**: `17 * * * *` (every hour at :17)
+- **Manual trigger**: Available via `workflow_dispatch`
+
+## Full Feedback Loop
+
+```
+self-assess (daily 04:37)        auto-fix (hourly :17)
+      │                                │
+      ▼                                ▼
+ Scan codebase ──── creates ────► Backlog issues
+ + infra metrics                       │
+                                       ▼
+                              Pick highest priority
+                                       │
+                                       ▼
+                              Assign Copilot ──► PR with fix
+                                                    │
+                                                    ▼
+                                              Human review
+                                                    │
+                                                    ▼
+                                              Merge ──► Next self-assess
+                                                        detects fix, closes issue
+```


### PR DESCRIPTION
Adds the auto-fix companion workflow that completes the self-improving codebase feedback loop.

## What it does

- Runs hourly at :17
- Checks mutex: if Copilot has a draft PR (actively working), skips
- Picks highest priority self-assess issue (priority labels > bumps > age)
- Skips infra-labeled issues (belong to my-infra repo)
- Assigns Copilot to implement the fix

## Changes

- NEW auto-fix.yml workflow
- self-assess.yml: creates priority-high/medium/low and infra labels
- SKILL.md: rule 4 requires priority + infra labels on all issues
- SELF-ASSESSMENT.md: documents auto-fix flow and full feedback loop
