### PR TITLE
Fix auto-fix.yml: add missing steps: key

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -12,6 +12,7 @@ jobs:
   auto-fix:
     runs-on: ubuntu-latest
     environment: copilot
+    steps:
     - name: Check for in-flight Copilot session
       id: mutex
       env:


### PR DESCRIPTION
The \nvironment: copilot\ addition from #115 replaced the \steps:\ key instead of being added before it, causing an invalid workflow YAML error on line 12.