### PR TITLE
Fix auto-fix.yml: use comment count instead of comments array

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -60,7 +60,7 @@ jobs:
                   else 1
                   end)
             ]
-            | sort_by([-.priority, -.comments, .createdAt])
+            | sort_by([-.priority, -(.comments | length), .createdAt])
             | .[0]
             | .number // empty')
 


### PR DESCRIPTION
The \gh issue list --json comments\ returns an array of comment objects, not a numeric count. The jq \sort_by(-.comments)\ fails with \cannot negate: array\. Fixed to use \-(.comments | length)\.