### PR TITLE
Fix auto-fix.yml: use REST API to assign Copilot

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         ISSUE=${{ steps.pick.outputs.issue }}
         echo "Assigning Copilot to issue #$ISSUE"
-        gh issue edit "$ISSUE" \
-          --repo "${{ github.repository }}" \
-          --add-assignee "copilot" \
+        gh api "repos/${{ github.repository }}/issues/$ISSUE/assignees" \
+          --method POST \
+          -f 'assignees[]=copilot' \
           || echo "WARNING: Failed to assign Copilot to #$ISSUE"


### PR DESCRIPTION
gh issue edit --add-assignee copilot fails with copilot not found. Use REST API endpoint instead.