### PR TITLE
Fix auto-fix.yml: use @copilot for assignment

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         ISSUE=${{ steps.pick.outputs.issue }}
         echo "Assigning Copilot to issue #$ISSUE"
-        gh api "repos/${{ github.repository }}/issues/$ISSUE/assignees" \
-          --method POST \
-          -f 'assignees[]=copilot' \
+        gh issue edit "$ISSUE" \
+          --repo "${{ github.repository }}" \
+          --add-assignee "@copilot" \
           || echo "WARNING: Failed to assign Copilot to #$ISSUE"


### PR DESCRIPTION
REST API POST /issues/assignees silently ignores copilot. Switch to gh issue edit --add-assignee @copilot which has the same special Copilot handling as gh issue create --assignee @copilot.