### PR TITLE
fix: heredoc syntax error in self-assess and auto-fix workflows

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -82,7 +82,7 @@ jobs:
         echo "Assigning Copilot to issue #$ISSUE"
         ASSIGNED=false
         for i in 1 2 3; do
-          gh api --method POST \
+          if gh api --method POST \
             "/repos/${{ github.repository }}/issues/${ISSUE}/assignees" \
             --input - <<EOF
         {
@@ -90,8 +90,14 @@ jobs:
           "agent_assignment": {}
         }
         EOF
-          && { ASSIGNED=true; echo "Assigned Copilot (default coding agent) to issue #$ISSUE"; break; } \
-          || { echo "WARNING: Assignment attempt $i failed for issue #$ISSUE"; sleep 5; }
+          then
+            ASSIGNED=true
+            echo "Assigned Copilot (default coding agent) to issue #$ISSUE"
+            break
+          else
+            echo "WARNING: Assignment attempt $i failed for issue #$ISSUE"
+            sleep 5
+          fi
         done
         if [ "$ASSIGNED" = false ]; then
           echo "ERROR: All 3 assignment attempts failed for issue #$ISSUE"

--- a/.github/workflows/self-assess.yml
+++ b/.github/workflows/self-assess.yml
@@ -147,7 +147,7 @@ jobs:
         # Assign Copilot with custom agent via REST API (retry up to 3 times)
         ASSIGNED=false
         for i in 1 2 3; do
-          gh api --method POST \
+          if gh api --method POST \
             "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/assignees" \
             --input - <<EOF
         {
@@ -157,8 +157,14 @@ jobs:
           }
         }
         EOF
-          && { ASSIGNED=true; echo "Assigned Copilot (self-assess agent) to issue #${ISSUE_NUMBER}"; break; } \
-          || { echo "WARNING: Assignment attempt $i failed for issue #${ISSUE_NUMBER}"; sleep 5; }
+          then
+            ASSIGNED=true
+            echo "Assigned Copilot (self-assess agent) to issue #${ISSUE_NUMBER}"
+            break
+          else
+            echo "WARNING: Assignment attempt $i failed for issue #${ISSUE_NUMBER}"
+            sleep 5
+          fi
         done
         if [ "$ASSIGNED" = false ]; then
           echo "ERROR: All 3 assignment attempts failed for issue #${ISSUE_NUMBER}"


### PR DESCRIPTION
Fixes syntax error: bash cannot chain && after a heredoc EOF terminator. The command is considered complete at EOF, so && on the next line is unexpected.

Restructured retry loops in both workflows to use if/then/else/fi which properly handles heredoc control flow.

Error was: line 37: syntax error near unexpected token &&