### PR TITLE
fix: YAML syntax error in guard-agent-prs workflow

### DIFF
--- a/.github/workflows/guard-agent-prs.yml
+++ b/.github/workflows/guard-agent-prs.yml
@@ -16,6 +16,12 @@ jobs:
     - name: Auto-close PRs from non-coding agent branches
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GUARD_COMMENT: |
+          🛑 **Auto-closed by guard workflow.**
+
+          Non-coding agents (project, product) must not create PRs. Their only deliverables are GitHub issues and comments. This PR was likely created by the Copilot platform after the agent violated its command allowlist by pushing commits.
+
+          The branch has been deleted. If the agent identified real issues, they should exist as GitHub issues in the backlog.
       run: |
         BRANCH="${{ github.head_ref }}"
         PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -25,17 +31,9 @@ jobs:
         # commits — this workflow catches and closes them immediately.
         if [[ "$BRANCH" =~ ^copilot/(daily-project-assessment|daily-self-assessment|project-assessment|product-analysis) ]]; then
           echo "🛑 Detected non-coding agent PR from branch: $BRANCH"
-          COMMENT=$(cat <<'EOF'
-🛑 **Auto-closed by guard workflow.**
-
-Non-coding agents (project, product) must not create PRs. Their only deliverables are GitHub issues and comments. This PR was likely created by the Copilot platform after the agent violated its command allowlist by pushing commits.
-
-The branch has been deleted. If the agent identified real issues, they should exist as GitHub issues in the backlog.
-EOF
-          )
           gh pr close "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --comment "$COMMENT" \
+            --comment "$GUARD_COMMENT" \
             --delete-branch \
             || echo "WARNING: Failed to close PR #${PR_NUMBER}"
         else


### PR DESCRIPTION
Fixes the invalid workflow file error on line 29 of guard-agent-prs.yml.

The bash heredoc (cat <<'EOF') inside a YAML | block scalar produced unindented lines that the YAML parser rejected. Moved the comment text into a GUARD_COMMENT environment variable using YAML's native multiline | syntax instead.

Relates to workflow run: https://github.com/Szer/coupon-bot/actions/runs/22899428409