### PR TITLE
fix: Copilot PR Manager 404 — gh api implicit POST

### DIFF
--- a/.github/workflows/copilot-pr-manager.yml
+++ b/.github/workflows/copilot-pr-manager.yml
@@ -95,6 +95,7 @@ jobs:
           || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
 
         ACTION_REQUIRED=$(gh api "repos/${REPO}/actions/runs" \
+          --method GET \
           -f status=action_required \
           -f per_page=100 \
           -f created=">=${ONE_WEEK_AGO}" \


### PR DESCRIPTION
Fixes the Copilot PR Manager failures since PR #208 was merged.

Root cause: gh api changes the default HTTP method from GET to POST when -f flags are used. The refactoring in #208 moved query params from the URL to -f flags, which silently switched the request to POST. POST /repos/{owner}/actions/runs does not exist, returning 404.

Fix: Add --method GET explicitly.