### PR TITLE
fix: exclude custom agents from coding/review instructions

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "**"
-excludeAgent: "coding-agent"
+excludeAgent: "coding-agent, project, product, sre"
 ---
 
 # Code Review Instructions for coupon-hub-bot

--- a/.github/instructions/coding-agent.instructions.md
+++ b/.github/instructions/coding-agent.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "**"
-excludeAgent: "code-review"
+excludeAgent: "code-review, project, product, sre"
 ---
 
 # Coding Agent Instructions
@@ -30,6 +30,8 @@ excludeAgent: "code-review"
 ## Agent Roles and PR Authority
 
 The coding agent is the **ONLY** agent that creates branches, commits, and pull requests. Other agents (project, product, SRE) must never create branches, commits, or PRs, but may perform other actions defined in their runbooks (such as creating issues, comments, or triggering rollbacks).
+
+> **⚠️ Instruction file exclusions**: Files in `.github/instructions/` use `excludeAgent` frontmatter to prevent cross-contamination. Both `coding-agent.instructions.md` and `code-review.instructions.md` MUST exclude all custom agents (`project, product, sre`). If a new custom agent is added, it MUST be added to the `excludeAgent` list in both files — otherwise the agent will receive conflicting coding/review instructions and may break character.
 
 ## Issue Label Rules
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,6 +70,7 @@ Output:
 
 The coding agent is guardrailed from raw user signals — it only sees refined tickets (`bug`, `feature-request`). Labels `user-feedback`, `product`, `project`, and `deploy-failure` are reserved for their respective agents.
 
-Non-coding agents (project, product) are restricted by two layers of defense:
+Non-coding agents (project, product) are restricted by three layers of defense:
 1. **Command allowlist** in their agent prompts — only `gh issue`, `curl`, and read-only commands are permitted
-2. **Copilot PR Manager** (`copilot-pr-manager.yml`) — a cron workflow (every 5 min) that auto-closes any PR from non-coding agents by detecting `Custom agent used: project/product` in the PR body (skipping in-flight `[WIP]` PRs), and re-runs pending workflow runs for legitimate Copilot coding agent PRs
+2. **Instruction file exclusions** — `coding-agent.instructions.md` and `code-review.instructions.md` use `excludeAgent` frontmatter to exclude all custom agents (`project, product, sre`). Without this, custom agents receive conflicting coding instructions and may break character. **When adding a new custom agent, always add it to `excludeAgent` in both files.**
+3. **Copilot PR Manager** (`copilot-pr-manager.yml`) — a cron workflow (every 5 min) that auto-closes any PR from non-coding agents by detecting `Custom agent used: project/product` in the PR body (skipping in-flight `[WIP]` PRs), and re-runs pending workflow runs for legitimate Copilot coding agent PRs


### PR DESCRIPTION
Fixes the project agent breaking character and starting to code (#219).

**Root cause**: coding-agent.instructions.md had excludeAgent: code-review, meaning it applied to ALL other agents including project, product, and sre. The project agent received conflicting instructions — its own prompt saying 'analyze and manage issues' plus the coding agent instructions saying 'create branches, write tests, create PRs'. It got confused and started acting as a coding agent.

**Fix**: Both instruction files now exclude all custom agents:
- coding-agent.instructions.md: excludeAgent: code-review, project, product, sre
- code-review.instructions.md: excludeAgent: coding-agent, project, product, sre

Each custom agent now only receives its own .agent.md prompt without interference.