### PR TITLE
fix: use YAML array for excludeAgent in instruction files

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,6 +1,10 @@
 ---
 applyTo: "**"
-excludeAgent: "coding-agent, project, product, sre"
+excludeAgent:
+  - "coding-agent"
+  - "project"
+  - "product"
+  - "sre"
 ---
 
 # Code Review Instructions for coupon-hub-bot

--- a/.github/instructions/coding-agent.instructions.md
+++ b/.github/instructions/coding-agent.instructions.md
@@ -1,6 +1,10 @@
 ---
 applyTo: "**"
-excludeAgent: "code-review, project, product, sre"
+excludeAgent:
+  - "code-review"
+  - "project"
+  - "product"
+  - "sre"
 ---
 
 # Coding Agent Instructions


### PR DESCRIPTION
The previous comma-separated string syntax for excludeAgent didn't work — GitHub docs only document single-value examples. This tries YAML array syntax instead to properly exclude custom agents (project, product, sre) from receiving coding/review instructions.

This is an experiment — if YAML arrays aren't supported either, we'll need to strengthen the custom agent prompts as a fallback.

Related: #219 (project agent broke character due to receiving coding instructions)