### PR TITLE
fix: enable show_full_output on Claude Code Action

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -89,6 +89,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: "true"
         prompt: |
           <instructions>
           ${{ env.AGENT_PROMPT }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,6 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: "true"
           prompt: |
             Review this PR using the code review rules in CLAUDE.md.
             Focus on: bugs, security, F# convention violations, missing tests.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,6 +210,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: "true"
         prompt: |
           <instructions>
           ${{ env.AGENT_PROMPT }}

--- a/.github/workflows/feedback-triage.yml
+++ b/.github/workflows/feedback-triage.yml
@@ -73,6 +73,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: "true"
         prompt: |
           <instructions>
           ${{ env.AGENT_PROMPT }}

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -145,6 +145,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: "true"
         prompt: |
           <instructions>
           ${{ env.AGENT_PROMPT }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -136,6 +136,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: "true"
         prompt: |
           <instructions>
           ${{ env.AGENT_PROMPT }}


### PR DESCRIPTION
## Summary
- Add `show_full_output: "true"` to all 6 Claude Code Action steps
- Agent errors and output will now appear in workflow logs instead of being silently swallowed

Discovered when debugging a "Credit balance is too low" error that was invisible in the UI.

## Test plan
- [ ] Re-run project workflow after merging, verify logs show agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)