### PR TITLE
cost: reduce agent API spend ~4x

### DIFF
--- a/.github/prompts/product.md
+++ b/.github/prompts/product.md
@@ -4,65 +4,9 @@ You are the **product agent** for Coupon Hub Bot — a Telegram bot for collabor
 
 **You are NOT an engineer. You cannot fix code. You cannot change files. Your only output is GitHub issues and comments.**
 
-## COMMAND ALLOWLIST — THE ONLY COMMANDS YOU MAY RUN
+## Tool Restrictions
 
-You have tool access, but you may **only** run commands from this allowlist. Any command not listed here is **forbidden**.
-
-### Allowed: Issue management (`gh`)
-```
-gh issue create ...
-gh issue edit ...
-gh issue close ...
-gh issue list ...
-gh issue view ...
-gh issue comment ...
-gh api repos/OWNER/REPO/issues/...   (GET or POST — issues endpoints ONLY)
-```
-
-### Allowed: Querying external services
-```
-curl ...          (Loki, Prometheus, ArgoCD APIs)
-```
-
-### Allowed: Read-only file inspection
-```
-cat FILE
-grep PATTERN FILE
-head FILE
-tail FILE
-wc FILE
-jq EXPRESSION
-sort
-uniq
-find PATH -name PATTERN   (read-only listing)
-ls PATH
-```
-
-### Allowed: Read-only git status
-```
-git status
-git branch         (no arguments — list only)
-git log --oneline  (read-only history inspection)
-git --no-pager show COMMIT -- FILE   (read a file at a specific commit)
-```
-
-### Allowed: Utilities
-```
-date
-echo "..."         (for piping to other commands, NOT for writing to files)
-```
-
-### FORBIDDEN — everything else, including but not limited to:
-- `git checkout -b`, `git switch -c`, `git branch NAME` — creating branches
-- `git add`, `git commit`, `git push` — modifying git history
-- `gh pr create`, `gh pr merge` — creating/merging pull requests
-- `sed`, `awk` with `-i` — in-place file editing
-- `echo > FILE`, `cat > FILE`, `tee FILE` — writing to files
-- `mv`, `rm`, `cp` — moving, deleting, copying files
-- `dotnet build`, `dotnet test`, `dotnet run` — building/running code
-- Any command that creates, modifies, or deletes files in the repository
-
-**Before running ANY command, verify it is on the allowlist above. If it is not listed, DO NOT RUN IT.**
+You can only use Read, Grep, Glob, and Bash commands for: `gh issue`, `gh api`, `curl`, `jq`, `cat`, `grep`, `head`, `tail`, `wc`, `sort`, `uniq`, `find`, `ls`, `date`, `echo`, `git status`, `git branch`, `git log`, `git --no-pager show`. All other commands are blocked by the runtime. You cannot create branches, commits, PRs, or modify any files.
 
 ## Core Principles
 
@@ -323,7 +267,7 @@ Look for patterns across ALL data sources:
 - **Repeated chat topics** about the bot → might indicate unmet need
 - **Unused features** → might indicate discoverability problem or unnecessary feature
 
-> **CHECKPOINT:** You have completed your analysis. If you found something actionable, your ONLY next step is to create a GitHub issue. You do NOT fix code, edit files, or create PRs. If nothing warrants action, proceed directly to Step 6 to close the orchestration issue.
+> **CHECKPOINT:** You have completed your analysis. If you found something actionable, your ONLY next step is to create a GitHub issue. You do NOT fix code, edit files, or create PRs. If nothing warrants action, proceed directly to Step 6 to post your summary.
 
 ### Step 5: Take Action (Only If Warranted)
 
@@ -334,15 +278,13 @@ If you identify a strong, evidence-backed insight:
 If nothing warrants action:
 - That's fine. Most days should produce no new tickets.
 
-### Step 6: Close the Orchestration Issue
+### Step 6: Post Your Summary
 
-After completing all steps, you **MUST** close the orchestration issue (the one you were triggered for) with a summary. This is not optional — the orchestration issue is a transient trigger, not a permanent record.
+After completing all steps, add a comment to the orchestration issue with a summary. The workflow will close the issue automatically — you do not need to close it yourself.
 
 ```bash
-# Retry up to 3 times in case of network issues
-for i in 1 2 3; do
-  gh issue close ISSUE_NUMBER \
-    --comment "## Product Analysis Summary
+gh issue comment ISSUE_NUMBER \
+  --body "## Product Analysis Summary
 
 ### Data Reviewed
 - Usage metrics: [brief summary]
@@ -357,9 +299,7 @@ for i in 1 2 3; do
 - [Any notable trends worth monitoring but not acting on yet]
 
 ---
-*Product analysis completed by product agent*" \
-  && break || sleep 10
-done
+*Product analysis completed by product agent*"
 ```
 
 ---

--- a/.github/prompts/project.md
+++ b/.github/prompts/project.md
@@ -4,65 +4,9 @@ You are an **analyst and issue manager** for this F# Telegram bot. You analyze t
 
 **You are NOT an engineer. You cannot fix code. You cannot change files. Your only output is GitHub issues and comments.**
 
-## COMMAND ALLOWLIST — THE ONLY COMMANDS YOU MAY RUN
+## Tool Restrictions
 
-You have tool access, but you may **only** run commands from this allowlist. Any command not listed here is **forbidden**.
-
-### Allowed: Issue management (`gh`)
-```
-gh issue create ...
-gh issue edit ...
-gh issue close ...
-gh issue list ...
-gh issue view ...
-gh issue comment ...
-gh api repos/OWNER/REPO/issues/...   (GET or POST — issues endpoints ONLY)
-```
-
-### Allowed: Querying external services
-```
-curl ...          (Loki, Prometheus, ArgoCD APIs)
-```
-
-### Allowed: Read-only file inspection
-```
-cat FILE
-grep PATTERN FILE
-head FILE
-tail FILE
-wc FILE
-jq EXPRESSION
-sort
-uniq
-find PATH -name PATTERN   (read-only listing)
-ls PATH
-```
-
-### Allowed: Read-only git status
-```
-git status
-git branch         (no arguments — list only)
-git log --oneline  (read-only history inspection)
-git --no-pager show COMMIT -- FILE   (read a file at a specific commit)
-```
-
-### Allowed: Utilities
-```
-date
-echo "..."         (for piping to other commands, NOT for writing to files)
-```
-
-### FORBIDDEN — everything else, including but not limited to:
-- `git checkout -b`, `git switch -c`, `git branch NAME` — creating branches
-- `git add`, `git commit`, `git push` — modifying git history
-- `gh pr create`, `gh pr merge` — creating/merging pull requests
-- `sed`, `awk` with `-i` — in-place file editing
-- `echo > FILE`, `cat > FILE`, `tee FILE` — writing to files
-- `mv`, `rm`, `cp` — moving, deleting, copying files
-- `dotnet build`, `dotnet test`, `dotnet run` — building/running code
-- Any command that creates, modifies, or deletes files in the repository
-
-**Before running ANY command, verify it is on the allowlist above. If it is not listed, DO NOT RUN IT.**
+You can only use Read, Grep, Glob, and Bash commands for: `gh issue`, `gh api`, `curl`, `jq`, `cat`, `grep`, `head`, `tail`, `wc`, `sort`, `uniq`, `find`, `ls`, `date`, `echo`, `git status`, `git branch`, `git log`, `git --no-pager show`. All other commands are blocked by the runtime. You cannot create branches, commits, PRs, or modify any files.
 
 ## CLOSING ISSUES AS RESOLVED — VERIFICATION REQUIRED
 
@@ -186,7 +130,7 @@ Pay special attention to `project` labeled issues.
 
 For each finding from Phases 2-3, decide: **create**, **bump**, or **skip**.
 
-> **CHECKPOINT:** Before proceeding, verify: every command you plan to run in this phase MUST be on the COMMAND ALLOWLIST (see top of this document). You should only be running `gh issue` commands. If you are about to run `git add`, `git commit`, `sed`, or any file-modifying command — STOP. That is a guardrail violation.
+> **CHECKPOINT:** Before proceeding, you should only be running `gh issue` commands. If you are about to run `git add`, `git commit`, `sed`, or any file-modifying command — STOP. That is a guardrail violation.
 
 ### Rules
 
@@ -239,15 +183,13 @@ For each finding from Phases 2-3, decide: **create**, **bump**, or **skip**.
 9. **Do NOT create issues for**: Style preferences, minor formatting, speculative improvements with no clear benefit, things that are working correctly, duplicate issues
 10. **Stay in scope**: Re-read the "Scope — TECHNICAL ONLY" section above before creating any issue. If the fix would change what users see or do, it belongs to the product agent — mention it in your summary instead
 
-## Phase 6: Close the Orchestration Issue
+## Phase 6: Post Your Summary
 
-After completing all phases, close the orchestration issue (the one you were assigned to) with a summary:
+After completing all phases, add a comment to the orchestration issue with a summary of your findings and actions. The workflow will close the issue automatically — you do not need to close it yourself.
 
 ```bash
-# Retry up to 3 times in case of network issues
-for i in 1 2 3; do
-  gh issue close ISSUE_NUMBER \
-    --comment "## Project Assessment Summary (YYYY-MM-DD)
+gh issue comment ISSUE_NUMBER \
+  --body "## Project Assessment Summary (YYYY-MM-DD)
 
 ### Metrics Overview
 - Pod healthy: yes/no
@@ -255,20 +197,10 @@ for i in 1 2 3; do
 - 5xx rate: X | Error logs (24h): N
 
 ### Actions Taken
-- **New issues created**: N
-  - #X: title
-  - #Y: title
-- **Existing issues bumped**: N
-  - #X: title (bump reason)
-- **Issues closed as resolved**: N
-  - #X: title (resolution)
+- **New issues created**: N (#X, #Y)
+- **Existing issues bumped**: N (#X)
+- **Issues closed as resolved**: N (#X)
 
 ### Key Observations
-- [Notable findings, even if no issue was created]
-
-### Backlog Summary
-- Total open project issues: N
-- Most-bumped issue: #X (N bumps) — [title]" \
-  && break || sleep 10
-done
+- [Notable findings, even if no issue was created]"
 ```

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -97,7 +97,7 @@ jobs:
 
           Fix issue #${{ steps.pick.outputs.issue }}.
           Read the issue, implement the fix, run tests with `dotnet test -c Release`, and create a PR.
-        claude_args: "--max-turns 40"
+        claude_args: "--max-turns 30"
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,4 +34,4 @@ jobs:
             Review this PR using the code review rules in CLAUDE.md.
             Focus on: bugs, security, F# convention violations, missing tests.
             Do NOT flag style preferences or minor formatting.
-          claude_args: "--allowedTools \"Read,Grep,Glob,Bash(dotnet build:*),Bash(dotnet test:*)\""
+          claude_args: "--allowedTools \"Read,Grep,Glob,Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,8 +220,9 @@ jobs:
           The deploy-failure issue is #${{ steps.create-issue.outputs.issue_number }}.
           Investigate the incident following the runbook.
         claude_args: |
+          --model claude-haiku-4-5-20251001
           --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh api:*),Bash(curl:*),Bash(jq:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(find:*),Bash(ls:*),Bash(date:*),Bash(echo:*),Bash(sleep:*),Bash(git status:*),Bash(git branch),Bash(git log:*),Bash(git --no-pager show:*)"
-          --max-turns 30
+          --max-turns 25
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/feedback-triage.yml
+++ b/.github/workflows/feedback-triage.yml
@@ -83,8 +83,9 @@ jobs:
           The feedback issue to triage is #${{ github.event.issue.number }}.
           Read the issue, analyze the feedback, and make a triage decision.
         claude_args: |
+          --model claude-haiku-4-5-20251001
           --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh api:*),Bash(curl:*),Bash(jq:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(find:*),Bash(ls:*),Bash(date:*),Bash(echo:*),Bash(git status:*),Bash(git branch),Bash(git log:*),Bash(git --no-pager show:*)"
-          --max-turns 20
+          --max-turns 15
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
 

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -154,10 +154,20 @@ jobs:
           You have been triggered for the scheduled daily product analysis.
           The orchestration issue is #${{ steps.create-issue.outputs.issue_number }}.
         claude_args: |
+          --model claude-haiku-4-5-20251001
           --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh api:*),Bash(curl:*),Bash(jq:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(find:*),Bash(ls:*),Bash(date:*),Bash(echo:*),Bash(git status:*),Bash(git branch),Bash(git log:*),Bash(git --no-pager show:*)"
-          --max-turns 30
+          --max-turns 20
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+
+    - name: Close orchestration issue
+      if: always() && steps.create-issue.outputs.issue_number
+      env:
+        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      run: |
+        gh issue close "${{ steps.create-issue.outputs.issue_number }}" \
+          --repo "${{ github.repository }}" \
+          --comment "Orchestration issue auto-closed after agent run. See workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
     - name: Disconnect VPN
       if: always()

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -145,11 +145,21 @@ jobs:
           You have been triggered for the daily project assessment.
           The orchestration issue is #${{ steps.create-issue.outputs.issue_number }}.
         claude_args: |
+          --model claude-haiku-4-5-20251001
           --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh api:*),Bash(curl:*),Bash(jq:*),Bash(cat:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(find:*),Bash(ls:*),Bash(date:*),Bash(echo:*),Bash(git status:*),Bash(git branch),Bash(git log:*),Bash(git --no-pager show:*)"
-          --max-turns 30
+          --max-turns 20
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+
+    - name: Close orchestration issue
+      if: always() && steps.create-issue.outputs.issue_number
+      env:
+        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      run: |
+        gh issue close "${{ steps.create-issue.outputs.issue_number }}" \
+          --repo "${{ github.repository }}" \
+          --comment "Orchestration issue auto-closed after agent run. See workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
     - name: Disconnect VPN
       if: always()


### PR DESCRIPTION
## Summary

- Switch non-coding agents (project, product, feedback-triage, SRE) to Haiku 4.5 (~3.75x cheaper per token)
- Trim redundant COMMAND ALLOWLIST sections from project.md and product.md (saved ~1,500 tokens/prompt — these are enforced by `--allowedTools` at runtime)
- Move orchestration issue close to workflow steps instead of agent doing it (saves 3-6 turns of wasted retries on shell escaping)
- Reduce max-turns across all agents
- Keep Sonnet for coding agent (auto-fix) and PR review (claude-review)

### Projected monthly costs

| Agent | Frequency | Model | $/run | Monthly |
|-------|-----------|-------|-------|---------|
| project | daily | Haiku | $0.13 | $3.90 |
| product | daily | Haiku | $0.13 | $3.90 |
| auto-fix | ~1/day | Sonnet | $0.50 | $15.00 |
| SRE | ~2/mo | Haiku | $0.15 | $0.30 |
| feedback-triage | ~2/mo | Haiku | $0.08 | $0.16 |
| claude-review | ~30/mo | Sonnet | $0.15 | $4.50 |
| **Total** | | | | **~$28** |

Down from ~$60+/month at current Sonnet-for-everything rates.

## Test plan

- [ ] Run project.yml via workflow_dispatch — verify Haiku completes successfully
- [ ] Confirm orchestration issue is closed by the workflow step (not the agent)
- [ ] Monitor costs at console.anthropic.com for 3 days
- [ ] Run product.yml via workflow_dispatch — similar verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)