### PR TITLE
fix: remove 'Ensure labels exist' steps from all workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,26 +146,6 @@ jobs:
         sudo chmod 600 /etc/wireguard/wg0.conf
         sudo wg-quick up wg0
 
-    - name: Ensure required labels exist
-      env:
-        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
-      run: |
-        gh label create deploy-failure \
-          --repo "${{ github.repository }}" \
-          --description "Automated deploy pipeline failure" \
-          --color "d93f0b" \
-          --force
-        gh label create priority-high \
-          --repo "${{ github.repository }}" \
-          --description "Reserved for user-reported high-priority issues (not used by project agent)" \
-          --color "b60205" \
-          --force
-        gh label create infra \
-          --repo "${{ github.repository }}" \
-          --description "Infrastructure issue — cannot be fixed in this repo" \
-          --color "d4c5f9" \
-          --force
-
     - name: Create debugging issue
       id: create-issue
       env:

--- a/.github/workflows/feedback-triage.yml
+++ b/.github/workflows/feedback-triage.yml
@@ -26,41 +26,6 @@ jobs:
         sudo chmod 600 /etc/wireguard/wg0.conf
         sudo wg-quick up wg0
 
-    - name: Ensure labels exist
-      env:
-        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
-      run: |
-        gh label create user-feedback \
-          --repo "${{ github.repository }}" \
-          --description "Raw user feedback — triaged by product agent only" \
-          --color "0075ca" \
-          --force
-        gh label create feature-request \
-          --repo "${{ github.repository }}" \
-          --description "Validated feature request from product agent triage" \
-          --color "a2eeef" \
-          --force
-        gh label create bug \
-          --repo "${{ github.repository }}" \
-          --description "Bug report" \
-          --color "d73a4a" \
-          --force
-        gh label create priority-high \
-          --repo "${{ github.repository }}" \
-          --description "Reserved for user-reported high-priority issues (not used by project agent)" \
-          --color "b60205" \
-          --force
-        gh label create priority-medium \
-          --repo "${{ github.repository }}" \
-          --description "Medium priority" \
-          --color "fbca04" \
-          --force
-        gh label create priority-low \
-          --repo "${{ github.repository }}" \
-          --description "Low priority — nice to have" \
-          --color "0e8a16" \
-          --force
-
     - name: Read product agent prompt
       run: |
         {

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -64,46 +64,6 @@ jobs:
         DATABASE_URL: ${{ secrets.DATABASE_URL }}
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
 
-    - name: Ensure labels exist
-      env:
-        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
-      run: |
-        gh label create product \
-          --repo "${{ github.repository }}" \
-          --description "Product agent orchestration issue" \
-          --color "d876e3" \
-          --force
-        gh label create user-feedback \
-          --repo "${{ github.repository }}" \
-          --description "Raw user feedback — triaged by product agent only" \
-          --color "0075ca" \
-          --force
-        gh label create feature-request \
-          --repo "${{ github.repository }}" \
-          --description "Validated feature request from product agent triage" \
-          --color "a2eeef" \
-          --force
-        gh label create bug \
-          --repo "${{ github.repository }}" \
-          --description "Bug report" \
-          --color "d73a4a" \
-          --force
-        gh label create priority-high \
-          --repo "${{ github.repository }}" \
-          --description "Reserved for user-reported high-priority issues (not used by project agent)" \
-          --color "b60205" \
-          --force
-        gh label create priority-medium \
-          --repo "${{ github.repository }}" \
-          --description "Medium priority" \
-          --color "fbca04" \
-          --force
-        gh label create priority-low \
-          --repo "${{ github.repository }}" \
-          --description "Low priority — nice to have" \
-          --color "0e8a16" \
-          --force
-
     - name: Create orchestration issue
       id: create-issue
       env:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -65,36 +65,6 @@ jobs:
         ARGOCD_APP_NAME: coupon-bot
         CONTAINER_NAME: coupon-bot
 
-    - name: Ensure labels exist
-      env:
-        GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
-      run: |
-        gh label create project \
-          --repo "${{ github.repository }}" \
-          --description "Managed by project agent — technical backlog" \
-          --color "7057ff" \
-          --force
-        gh label create infra \
-          --repo "${{ github.repository }}" \
-          --description "Infrastructure issue — cannot be fixed in this repo" \
-          --color "d4c5f9" \
-          --force
-        gh label create priority-high \
-          --repo "${{ github.repository }}" \
-          --description "Reserved for user-reported high-priority issues (not used by project agent)" \
-          --color "b60205" \
-          --force
-        gh label create priority-medium \
-          --repo "${{ github.repository }}" \
-          --description "Medium priority" \
-          --color "fbca04" \
-          --force
-        gh label create priority-low \
-          --repo "${{ github.repository }}" \
-          --description "Low priority — nice to have" \
-          --color "0e8a16" \
-          --force
-
     - name: Create orchestration issue
       id: create-issue
       env:


### PR DESCRIPTION
## Summary

- Remove "Ensure labels exist" steps from project.yml, product.yml, feedback-triage.yml, and deploy.yml
- These steps were failing due to GitHub API connection timeouts through VPN, blocking the entire workflow
- All labels already exist in the repo — no need to re-create them on every run
- If new labels are needed in the future, they should be created once during a PR, not on every workflow invocation

## Test plan

- [ ] Run project.yml via workflow_dispatch — verify it no longer fails on label creation
- [ ] Run product.yml via workflow_dispatch — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)