### PR TITLE
fix: add gh pr view/diff to review workflow allowedTools

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,4 +34,4 @@ jobs:
             Review this PR using the code review rules in CLAUDE.md.
             Focus on: bugs, security, F# convention violations, missing tests.
             Do NOT flag style preferences or minor formatting.
-          claude_args: "--allowedTools \"Read,Grep,Glob,Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"
+          claude_args: "--allowedTools \"Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"


### PR DESCRIPTION
## Summary

The review agent was completely broken — `--allowedTools` only had `Read,Grep,Glob,Bash(dotnet build:*),Bash(dotnet test:*)`, so the agent couldn't run any `gh pr` commands to read the PR diff or details. It tried `gh pr list` 3 times, got denied each time, and exited doing nothing.

Added `Bash(gh pr view:*)` and `Bash(gh pr diff:*)` so the agent can read PR content. These are read-only — no `gh pr create` or `gh pr merge`.

## Test plan

- [ ] This PR itself should trigger the review workflow — verify it actually posts a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)