### PR TITLE
fix: pass PR number to review agent prompt

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,9 +29,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          show_full_output: "true"
           prompt: |
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
             Review this PR using the code review rules in CLAUDE.md.
             Focus on: bugs, security, F# convention violations, missing tests.
             Do NOT flag style preferences or minor formatting.
-          claude_args: "--allowedTools \"Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"
+            The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }}` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments — don't submit review text as messages.
+          claude_args: "--allowedTools \"mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"


### PR DESCRIPTION
## Summary
- The review agent was broken — it spent all turns asking "which PR?" because the prompt never included the PR number
- Inlined `PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}` directly in the prompt, following the [recommended pattern](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#basic-example-no-tracking)
- Added `gh pr comment` and `mcp__github_inline_comment__create_inline_comment` to allowedTools so the agent can actually post review feedback

## Test plan
- [ ] Open a test PR and verify the review workflow runs and posts comments instead of asking for a PR number
- [ ] Comment `@claude` on a PR and verify it responds (uses `github.event.issue.number` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)