### PR TITLE
fix: add public DNS fallback after VPN connect

### DIFF
--- a/scripts/setup-vpn.sh
+++ b/scripts/setup-vpn.sh
@@ -23,8 +23,7 @@ sudo wg-quick up wg0
 # DNS server is primary.  Not needed for full-tunnel mode where
 # all traffic already routes through the VPN gateway.
 if [ "$SPLIT_TUNNEL" = "true" ]; then
-  echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf > /dev/null
-  echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf > /dev/null
+  printf "nameserver 8.8.8.8\nnameserver 8.8.4.4\n" | sudo resolvconf -a wg0.fallback -m 1
   echo "Added public DNS fallback (8.8.8.8, 8.8.4.4)"
 fi
 


### PR DESCRIPTION
## Summary
- `wg-quick up` overwrites `/etc/resolv.conf` with the VPN's internal DNS server, which can't resolve public hosts like `api.github.com`
- Appends Google public DNS (`8.8.8.8`, `8.8.4.4`) as fallback after VPN connect when split tunneling is enabled
- Fixes ~60% failure rate in `claude-code-action` steps across product, project, and SRE workflows

## Test plan
- [ ] Run `workflow_dispatch` on product workflow after merge — verify "Run product agent" step succeeds without DNS errors
- [ ] Verify "Close orchestration issue" step also succeeds
- [ ] Check that internal services (Prometheus, Loki, DB) still resolve during data gathering
- [ ] Spot-check a project workflow run for the same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)