### PR TITLE
fix: wave-gated review with approval verdicts

### DIFF
--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,0 +1,52 @@
+You are reviewing a pull request. You MUST end your review by submitting a formal verdict.
+
+## Review Rules
+
+Review using the code review rules in CLAUDE.md.
+Focus on: bugs, security, F# convention violations, missing validation, missing tests.
+Do NOT flag: style preferences, minor formatting, subjective naming choices.
+
+## Issue Categories
+
+- **BLOCKING**: bugs, security vulnerabilities, missing validation, data loss risks, deadlocks, missing GRANT in migrations. These warrant REQUEST_CHANGES.
+- **NON-BLOCKING**: convention suggestions, minor improvements, naming preferences. Mention these in inline comments but do NOT block the PR for them.
+
+## Wave-Specific Instructions
+
+### If REVIEW WAVE is 1:
+
+This is the FIRST review. Be thorough and find ALL issues in a single pass.
+
+1. Read the full diff with `gh pr diff PR_NUMBER`
+2. Check every changed file systematically — do not skip any
+3. Post inline comments for specific code issues using `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`)
+4. After reviewing ALL files, submit your verdict:
+   - If you found BLOCKING issues: `gh pr review PR_NUMBER --request-changes -b "Found N blocking issue(s): <brief list>"`
+   - If no blocking issues (even if you posted non-blocking suggestions): `gh pr review PR_NUMBER --approve -b "LGTM. N non-blocking suggestions posted as comments."`
+   - If the PR is clean: `gh pr review PR_NUMBER --approve -b "LGTM — no issues found."`
+
+Do not leave anything for a follow-up review. This is your only chance to be thorough.
+
+### If REVIEW WAVE is 2:
+
+This is a RE-REVIEW after the author pushed fixes. Be strict about signal-to-noise.
+
+1. Read the full diff with `gh pr diff PR_NUMBER`
+2. ONLY flag issues that are:
+   (a) NEW bugs or security issues in newly added/changed code, OR
+   (b) Previous blocking issues that were NOT actually fixed
+3. Do NOT raise new minor or non-blocking issues — wave 1 was your chance
+4. Do NOT repeat concerns already addressed
+5. Submit your verdict:
+   - If critical issues remain: `gh pr review PR_NUMBER --request-changes -b "N critical issue(s) still unresolved: <brief list>"`
+   - Otherwise: `gh pr review PR_NUMBER --approve -b "Fixes look good. Approved."`
+
+Lean toward approving. If you are unsure whether something is blocking, it is not.
+
+## Critical Rules
+
+- You MUST submit exactly one verdict via `gh pr review` before finishing
+- Never skip the verdict step — this is REQUIRED for the auto-merge pipeline
+- Use inline comments for specific code issues, the verdict body for a summary
+- Only post GitHub comments — don't submit review text as chat messages
+- Replace PR_NUMBER in commands above with the actual PR number provided

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,19 +25,51 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Count review waves
+        id: wave-check
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REVIEW_COUNT=$(gh api \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[.[] | select(.user.type == "Bot" and (.state == "APPROVED" or .state == "CHANGES_REQUESTED"))] | length')
+          WAVE=$((REVIEW_COUNT + 1))
+          echo "wave=${WAVE}" >> "$GITHUB_OUTPUT"
+          echo "Review wave: ${WAVE}"
+
+      - name: Max review waves reached
+        if: github.event_name == 'pull_request' && steps.wave-check.outputs.wave > 2
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "Two automated review rounds completed. Remaining issues (if any) require human review."
+
+      - name: Read review prompt
+        if: >
+          (github.event_name != 'pull_request') ||
+          (steps.wave-check.outputs.wave <= 2)
+        run: |
+          {
+            echo "REVIEW_PROMPT<<PROMPT_EOF"
+            cat .github/prompts/review.md
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Run Claude review
+        if: >
+          (github.event_name != 'pull_request') ||
+          (steps.wave-check.outputs.wave <= 2)
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            REVIEW WAVE: ${{ steps.wave-check.outputs.wave || '1' }}
 
-            Review this PR using the code review rules in CLAUDE.md.
-            Focus on: bugs, security, F# convention violations, missing tests.
-            Do NOT flag style preferences or minor formatting.
-            The PR branch is already checked out in the current working directory.
-
-            Use `gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }}` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
-            Only post GitHub comments — don't submit review text as messages.
-          claude_args: "--allowedTools \"mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"
+            ${{ env.REVIEW_PROMPT }}
+          claude_args: "--allowedTools \"mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(dotnet build:*),Bash(dotnet test:*)\" --max-turns 10"
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}


### PR DESCRIPTION
## Summary

- **Wave counting**: counts previous bot reviews (APPROVED/CHANGES_REQUESTED) to determine review round
- **Wave 1**: thorough single-pass review — finds ALL issues at once, submits APPROVE or REQUEST_CHANGES verdict
- **Wave 2**: targeted re-review — only flags new/unfixed blocking issues, leans toward approving
- **Wave 3+**: skips Claude entirely, posts "human review needed" comment (saves budget)
- **Approval verdicts**: uses `gh pr review --approve` / `--request-changes` so the check status reflects actual review outcome (enables auto-merge)
- **Prompt extraction**: review prompt moved to `.github/prompts/review.md` (same pattern as coding agent)

## Problems solved

1. Incomplete first review → prompt now says "find ALL issues in this single pass"
2. Redundant re-reviews → wave 2 only flags new/unfixed blocking issues
3. Infinite loops → hard cap at 2 review waves
4. Marginal comments → wave 2 is strict about signal-to-noise, non-blocking issues don't warrant REQUEST_CHANGES
5. No approval → formal APPROVE/REQUEST_CHANGES verdict submitted every review

## Test plan

- [ ] Open a test PR with a known issue → verify wave 1 catches it and submits REQUEST_CHANGES
- [ ] Push a fix → verify wave 2 approves or only flags remaining issues
- [ ] Push again → verify wave 3 skips Claude and posts comment
- [ ] Test `@claude` mention → verify it still works (not wave-gated)
- [ ] Verify COPILOT_ASSIGN_PAT has sufficient permissions for `gh pr review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)