### PR TITLE
fix: revert to direct resolv.conf append for DNS fallback

### DIFF
--- a/scripts/setup-vpn.sh
+++ b/scripts/setup-vpn.sh
@@ -23,7 +23,11 @@ sudo wg-quick up wg0
 # DNS server is primary.  Not needed for full-tunnel mode where
 # all traffic already routes through the VPN gateway.
 if [ "$SPLIT_TUNNEL" = "true" ]; then
-  printf "nameserver 8.8.8.8\nnameserver 8.8.4.4\n" | sudo resolvconf -a wg0.fallback -m 1
+  # Append directly — resolvconf -a would trigger a full regeneration that
+  # drops the runner's original system DNS (breaking apt/public resolution).
+  # Direct append is safe in CI: the VPN connects once and nothing regenerates.
+  echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf > /dev/null
+  echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf > /dev/null
   echo "Added public DNS fallback (8.8.8.8, 8.8.4.4)"
 fi
 


### PR DESCRIPTION
## Summary
- `resolvconf -a` (from #261) triggers a full `/etc/resolv.conf` regeneration that drops the runner's original system DNS entries
- This broke `apt-get install postgresql-client` with `Temporary failure resolving 'azure.archive.ubuntu.com'` ([failed run](https://github.com/Szer/coupon-bot/actions/runs/23112508959/job/67132354262))
- Reverts to direct `tee -a /etc/resolv.conf` which is safe in CI (VPN connects once, no subsequent regeneration)

## Test plan
- [ ] Verify `apt-get install postgresql-client` succeeds after VPN connect
- [ ] Verify `api.github.com` still resolves (the original #261 fix)
- [ ] Verify internal services still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)