### PR TITLE
fix: add id-token: write permission to product and SRE workflows

### DIFF
--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
 

--- a/.github/workflows/sre.yml
+++ b/.github/workflows/sre.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   investigate:


### PR DESCRIPTION
## Summary
- `claude-code-action@v1` uses OIDC internally to mint a short-lived GitHub token for repo access (reading files, posting comments, etc.) — this requires `id-token: write` permission
- The permission was mistakenly removed from `product.yml` (in #259) and `sre.yml` (in 360de75) during recent overhauls, under the incorrect assumption that auth is only via `ANTHROPIC_API_KEY`
- This restores the permission to both workflows

## Test plan
- [ ] Re-run the product workflow and verify it no longer fails with OIDC token error
- [ ] Verify SRE workflow still triggers correctly on `deploy-failure` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)