### PR TITLE
fix: route DB IP through VPN in split-tunnel mode

### DIFF
--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -47,6 +47,7 @@ jobs:
         ./scripts/setup-vpn.sh
       env:
         WIREGUARD_CONFIG: ${{ secrets.WIREGUARD_CONFIG }}
+        VPN_EXTRA_CIDRS: ${{ vars.DB_PUBLIC_IP_CIDR }}
 
     - name: Install PostgreSQL client
       run: sudo apt-get install -y postgresql-client

--- a/scripts/setup-vpn.sh
+++ b/scripts/setup-vpn.sh
@@ -13,7 +13,11 @@ sudo chmod 600 /etc/wireguard/wg0.conf
 # via public endpoint + AKS firewall rule).
 SPLIT_TUNNEL="${SPLIT_TUNNEL:-true}"
 if [ "$SPLIT_TUNNEL" = "true" ]; then
-  sudo sed -i 's|AllowedIPs\s*=\s*0\.0\.0\.0/0.*|AllowedIPs = 10.0.0.0/8|' /etc/wireguard/wg0.conf
+  ALLOWED="10.0.0.0/8"
+  if [ -n "${VPN_EXTRA_CIDRS:-}" ]; then
+    ALLOWED="${ALLOWED}, ${VPN_EXTRA_CIDRS}"
+  fi
+  sudo sed -i "s|AllowedIPs\s*=\s*0\.0\.0\.0/0.*|AllowedIPs = ${ALLOWED}|" /etc/wireguard/wg0.conf
 fi
 
 sudo wg-quick up wg0


### PR DESCRIPTION
## Summary
- Split tunneling (`AllowedIPs = 10.0.0.0/8`) excludes the Azure DB at `128.251.74.12`, causing psql timeouts in the product workflow
- Added `VPN_EXTRA_CIDRS` env var support to `setup-vpn.sh` so extra CIDRs can be appended to AllowedIPs
- Product workflow now passes `vars.DB_PUBLIC_IP_CIDR` (`128.251.74.12/32`) to route DB traffic through VPN

## Test plan
- [ ] Merge and trigger product workflow via `workflow_dispatch`
- [ ] Confirm "Gather product data" step completes without psql timeout errors
- [ ] Confirm GitHub API calls (`gh issue create/list`) still work (split tunnel intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)