### PR TITLE
fix: add --allowedTools to coding agent workflows

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -97,7 +97,7 @@ jobs:
 
           Fix issue #${{ steps.pick.outputs.issue }}.
           Read the issue, implement the fix, run tests with `dotnet test -c Release`, and create a PR.
-        claude_args: "--max-turns 30"
+        claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 30"
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -54,7 +54,7 @@ jobs:
             Fix issue #${{ github.event.issue.number }}.
             Read the issue (including all comments — the latest comments contain the implementation plan),
             implement the fix, run tests with `dotnet test -c Release`, and create a PR.
-          claude_args: "--max-turns 30"
+          claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 30"
         env:
           GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Both `claude-implement.yml` and `auto-fix.yml` ran `claude-code-action` with `permissionMode: default`, which blocks `gh` and `git` bash commands in CI (no one to approve)
- The agent in [run 23116918521](https://github.com/Szer/coupon-bot/actions/runs/23116918521/job/67143989648) burned all 30 turns retrying `gh issue view 269` — every attempt returned "This command requires approval"
- Add `--allowedTools` whitelist to both workflows: file ops (`Read,Edit,Write,Glob,Grep`), git, gh issue/pr, dotnet, and basic shell commands

## Test plan
- [ ] Retrigger `@claude` on issue #269 — verify it can now read the issue and proceed with implementation
- [ ] Verify `auto-fix.yml` still works when it picks up an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)