### PR TITLE
fix: reduce coding agent turn waste and increase max turns to 50

### DIFF
--- a/.github/prompts/coding.md
+++ b/.github/prompts/coding.md
@@ -61,6 +61,16 @@ You are the **coding agent** for Coupon Hub Bot — an F# / .NET 10 Telegram bot
 - No new warnings (they are errors)
 - Follow existing code patterns and conventions
 
+## Efficient Turn Usage
+
+You have a limited turn budget. Optimize your turns:
+
+1. **Trust the plan**: If the issue comments contain a detailed implementation plan with specific files and code changes, follow it directly. Don't re-explore the entire codebase — only read files you need to edit.
+2. **Batch tool calls**: Make multiple Read/Edit/Write calls in parallel within a single turn when they are independent.
+3. **Reserve turns for finalization**: Always reserve at least 8 turns for: `dotnet build` → fix errors → `dotnet test` → fix failures → `git add/commit/push` → `gh pr create`. Start coding early.
+4. **Don't read all migrations**: Only read the latest migration to determine the next version number. The schema is documented in the issue plan.
+5. **Minimize re-reads**: Read each file once. If a file is too large, use offset/limit on the first try.
+
 ## What NOT to Do
 
 - Don't change unrelated code

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -97,7 +97,7 @@ jobs:
 
           Fix issue #${{ steps.pick.outputs.issue }}.
           Read the issue, implement the fix, run tests with `dotnet test -c Release`, and create a PR.
-        claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 30"
+        claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 50"
       env:
         GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
         ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -54,7 +54,7 @@ jobs:
             Fix issue #${{ github.event.issue.number }}.
             Read the issue (including all comments — the latest comments contain the implementation plan),
             implement the fix, run tests with `dotnet test -c Release`, and create a PR.
-          claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 30"
+          claude_args: "--allowedTools \"Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(dotnet build:*),Bash(dotnet test:*),Bash(dotnet restore:*),Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(mkdir:*)\" --max-turns 50"
         env:
           GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add "Efficient Turn Usage" section to `.github/prompts/coding.md` — guides the agent to trust issue plans, batch tool calls, reserve turns for build/test/PR, and avoid reading all migrations
- Increase `--max-turns` from 30 → 50 in both `claude-implement.yml` and `auto-fix.yml`

Motivated by issue #269 run where the agent exhausted all 30 turns on exploration and edits, never reaching `dotnet test` or `gh pr create` ($1.05 wasted).

## Test plan
- [ ] Retrigger `@claude` on issue #269
- [ ] Verify agent starts editing by ~turn 5, runs tests by ~turn 20, creates PR by ~turn 25
- [ ] Verify total cost stays under $2

🤖 Generated with [Claude Code](https://claude.com/claude-code)