### PR TITLE
feat: enrich /stats with utilization rate and global community stats

### DIFF
--- a/src/CouponHubBot/Services/CommandHandler.fs
+++ b/src/CouponHubBot/Services/CommandHandler.fs
@@ -111,9 +111,32 @@ type CommandHandler(
     let handleStats (user: DbUser) (chatId: int64) =
         task {
             let! added, taken, returned, used, voided = db.GetUserStats(user.id)
+            let! personal = db.GetPersonalCouponOutcomes(user.id)
+            let! globalStats = db.GetGlobalCouponStats()
+
+            let fmtRate (usedN: int64) (expiredN: int64) =
+                let denom = usedN + expiredN
+                if denom = 0L then "—"
+                else $"{int (round (float usedN / float denom * 100.0))}%%"
+
+            let personalRate = fmtRate personal.used_count personal.expired_count
+            let globalRate   = fmtRate globalStats.used_count globalStats.expired_count
+
             do!
                 sendText chatId
-                    $"Статистика:\nДобавлено: {added}\nВзято: {taken}\nВозвращено: {returned}\nИспользовано: {used}\nАннулировано: {voided}"
+                    ($"Статистика:\nДобавлено: {added} · Взято: {taken} · Возвращено: {returned} · Использовано: {used} · Аннулировано: {voided}\n\n"
+                    + $"Судьба моих купонов:\n"
+                    + $"Использовано: {personal.used_count}\n"
+                    + $"Истекло неиспользованными: {personal.expired_count}\n"
+                    + $"Сейчас активны: {personal.active_count}\n"
+                    + $"Аннулировано: {personal.voided_count}\n"
+                    + $"Утилизация: {personalRate}\n\n"
+                    + $"Сообщество (всего):\n"
+                    + $"Добавлено: {globalStats.total_count}\n"
+                    + $"Использовано: {globalStats.used_count}\n"
+                    + $"Истекло: {globalStats.expired_count}\n"
+                    + $"Активных сейчас: {globalStats.active_count}\n"
+                    + $"Утилизация: {globalRate}")
         }
 
     let handleMy (user: DbUser) (chatId: int64) =

--- a/src/CouponHubBot/Services/DbService.fs
+++ b/src/CouponHubBot/Services/DbService.fs
@@ -56,6 +56,14 @@ type EventTypeCountRow =
       count: int64 }
 
 [<CLIMutable>]
+type CouponOutcomes =
+    { used_count: int64
+      expired_count: int64
+      active_count: int64
+      voided_count: int64
+      total_count: int64 }
+
+[<CLIMutable>]
 type ChatMessageRow =
     { user_id: int64
       message_id: int
@@ -333,6 +341,43 @@ GROUP BY event_type;
                 |> Option.defaultValue 0L
 
             return get "added", get "taken", get "returned", get "used", get "voided"
+        }
+
+    member _.GetPersonalCouponOutcomes(userId: int64) =
+        task {
+            use! conn = openConn()
+            let today = todayUtc ()
+            //language=postgresql
+            let sql =
+                """
+SELECT
+    COUNT(*) FILTER (WHERE status = 'used')::bigint                                          AS used_count,
+    COUNT(*) FILTER (WHERE status IN ('available','taken') AND expires_at < @today)::bigint  AS expired_count,
+    COUNT(*) FILTER (WHERE status IN ('available','taken') AND expires_at >= @today)::bigint AS active_count,
+    COUNT(*) FILTER (WHERE status = 'voided')::bigint                                        AS voided_count,
+    COUNT(*)::bigint                                                                         AS total_count
+FROM coupon
+WHERE owner_id = @user_id;
+"""
+            return! conn.QuerySingleAsync<CouponOutcomes>(sql, {| user_id = userId; today = today |})
+        }
+
+    member _.GetGlobalCouponStats() =
+        task {
+            use! conn = openConn()
+            let today = todayUtc ()
+            //language=postgresql
+            let sql =
+                """
+SELECT
+    COUNT(*) FILTER (WHERE status = 'used')::bigint                                          AS used_count,
+    COUNT(*) FILTER (WHERE status IN ('available','taken') AND expires_at < @today)::bigint  AS expired_count,
+    COUNT(*) FILTER (WHERE status IN ('available','taken') AND expires_at >= @today)::bigint AS active_count,
+    COUNT(*) FILTER (WHERE status = 'voided')::bigint                                        AS voided_count,
+    COUNT(*)::bigint                                                                         AS total_count
+FROM coupon;
+"""
+            return! conn.QuerySingleAsync<CouponOutcomes>(sql, {| today = today |})
         }
 
     member _.TryTakeCoupon(couponId, takerId) =

--- a/tests/CouponHubBot.Tests/CouponHubBot.Tests.fsproj
+++ b/tests/CouponHubBot.Tests/CouponHubBot.Tests.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="FeedbackFlowTests.fs" />
     <Compile Include="AdminDebugTests.fs" />
     <Compile Include="VoidFlowTests.fs" />
+    <Compile Include="StatsTests.fs" />
     <Compile Include="HealthCheckTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/tests/CouponHubBot.Tests/StatsTests.fs
+++ b/tests/CouponHubBot.Tests/StatsTests.fs
@@ -1,0 +1,191 @@
+namespace CouponHubBot.Tests
+
+open System.Net
+open System.Threading.Tasks
+open Dapper
+open Npgsql
+open Xunit
+open FakeCallHelpers
+
+type StatsTests(fixture: DefaultCouponHubTestContainers) =
+
+    let seedUser (conn: NpgsqlConnection) (userId: int64) (username: string) =
+        conn.ExecuteAsync(
+            """
+INSERT INTO "user"(id, username, first_name, created_at, updated_at)
+VALUES (@id, @username, @username, NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;
+""",
+            {| id = userId; username = username |}
+        )
+
+    [<Fact>]
+    let ``Stats shows personal outcome breakdown with correct counts and utilization`` () =
+        task {
+            do! fixture.ClearFakeCalls()
+            do! fixture.TruncateCoupons()
+
+            use conn = new NpgsqlConnection(fixture.DbConnectionString)
+            let userId = 9100L
+            let! _ = seedUser conn userId "stats_user_9100"
+
+            // 2 used, 2 expired (1 available + 1 taken, past date), 1 active, 1 voided
+            do!
+                conn.ExecuteAsync(
+                    """
+INSERT INTO coupon(owner_id, photo_file_id, value, min_check, expires_at, status)
+VALUES
+  (9100, 'stats-p1', 10, 50, '2025-06-01', 'used'),
+  (9100, 'stats-p2', 10, 50, '2025-06-01', 'used'),
+  (9100, 'stats-p3', 10, 50, '2025-06-01', 'available'),
+  (9100, 'stats-p4', 10, 50, '2025-06-01', 'taken'),
+  (9100, 'stats-p5', 10, 50, '2026-06-01', 'available'),
+  (9100, 'stats-p6', 10, 50, '2026-06-01', 'voided');
+"""
+                )
+                :> Task
+
+            let user = Tg.user(id = userId, username = "stats_user_9100", firstName = "StatsUser")
+            do! fixture.SetChatMemberStatus(user.Id, "member")
+            let! resp = fixture.SendUpdate(Tg.dmMessage("/stats", user))
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+
+            let! calls = fixture.GetFakeCalls("sendMessage")
+
+            Assert.True(findCallWithText calls userId "Судьба моих купонов",
+                "Expected personal outcomes section header")
+            Assert.True(findCallWithText calls userId "Использовано: 2",
+                "Expected 2 used in personal section")
+            Assert.True(findCallWithText calls userId "Истекло неиспользованными: 2",
+                "Expected 2 expired in personal section")
+            Assert.True(findCallWithText calls userId "Сейчас активны: 1",
+                "Expected 1 active in personal section")
+            Assert.True(findCallWithText calls userId "Аннулировано: 1",
+                "Expected 1 voided in personal section")
+            // 2 used / (2 used + 2 expired) = 50%
+            Assert.True(findCallWithText calls userId "Утилизация: 50%",
+                "Expected 50% utilization rate")
+        }
+
+    [<Fact>]
+    let ``Stats shows global community section`` () =
+        task {
+            do! fixture.ClearFakeCalls()
+            do! fixture.TruncateCoupons()
+
+            use conn = new NpgsqlConnection(fixture.DbConnectionString)
+            let userId = 9101L
+            let! _ = seedUser conn userId "stats_user_9101"
+
+            do!
+                conn.ExecuteAsync(
+                    """
+INSERT INTO coupon(owner_id, photo_file_id, value, min_check, expires_at, status)
+VALUES
+  (9101, 'global-p1', 10, 50, '2025-06-01', 'used'),
+  (9101, 'global-p2', 10, 50, '2026-06-01', 'available');
+"""
+                )
+                :> Task
+
+            let user = Tg.user(id = userId, username = "stats_user_9101", firstName = "Global")
+            do! fixture.SetChatMemberStatus(user.Id, "member")
+            let! resp = fixture.SendUpdate(Tg.dmMessage("/stats", user))
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+
+            let! calls = fixture.GetFakeCalls("sendMessage")
+
+            Assert.True(findCallWithText calls userId "Сообщество (всего)",
+                "Expected global stats section header")
+            Assert.True(findCallWithText calls userId "Добавлено: 2",
+                "Expected global total_count = 2")
+        }
+
+    [<Fact>]
+    let ``Stats shows 100 percent utilization when all added coupons were used`` () =
+        task {
+            do! fixture.ClearFakeCalls()
+            do! fixture.TruncateCoupons()
+
+            use conn = new NpgsqlConnection(fixture.DbConnectionString)
+            let userId = 9102L
+            let! _ = seedUser conn userId "stats_user_9102"
+
+            do!
+                conn.ExecuteAsync(
+                    """
+INSERT INTO coupon(owner_id, photo_file_id, value, min_check, expires_at, status)
+VALUES
+  (9102, 'full-p1', 10, 50, '2025-06-01', 'used'),
+  (9102, 'full-p2', 10, 50, '2025-06-01', 'used'),
+  (9102, 'full-p3', 10, 50, '2025-06-01', 'used');
+"""
+                )
+                :> Task
+
+            let user = Tg.user(id = userId, username = "stats_user_9102", firstName = "FullRate")
+            do! fixture.SetChatMemberStatus(user.Id, "member")
+            let! resp = fixture.SendUpdate(Tg.dmMessage("/stats", user))
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+
+            let! calls = fixture.GetFakeCalls("sendMessage")
+
+            Assert.True(findCallWithText calls userId "Утилизация: 100%",
+                "Expected 100% utilization when all coupons were used")
+        }
+
+    [<Fact>]
+    let ``Stats shows dash for utilization when user has no terminal coupons`` () =
+        task {
+            do! fixture.ClearFakeCalls()
+            do! fixture.TruncateCoupons()
+
+            use conn = new NpgsqlConnection(fixture.DbConnectionString)
+            let userId = 9103L
+            let! _ = seedUser conn userId "stats_user_9103"
+
+            // One active coupon (not expired, not used) — denominator is 0
+            do!
+                conn.ExecuteAsync(
+                    """
+INSERT INTO coupon(owner_id, photo_file_id, value, min_check, expires_at, status)
+VALUES (9103, 'dash-p1', 10, 50, '2026-06-01', 'available');
+"""
+                )
+                :> Task
+
+            let user = Tg.user(id = userId, username = "stats_user_9103", firstName = "NoTerminal")
+            do! fixture.SetChatMemberStatus(user.Id, "member")
+            let! resp = fixture.SendUpdate(Tg.dmMessage("/stats", user))
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+
+            let! calls = fixture.GetFakeCalls("sendMessage")
+
+            Assert.True(findCallWithText calls userId "Утилизация: —",
+                "Expected dash when no used or expired coupons exist")
+            Assert.True(findCallWithText calls userId "Сейчас активны: 1",
+                "Expected 1 active coupon")
+        }
+
+    [<Fact>]
+    let ``Stats works for user who has never added any coupons`` () =
+        task {
+            do! fixture.ClearFakeCalls()
+            do! fixture.TruncateCoupons()
+
+            use conn = new NpgsqlConnection(fixture.DbConnectionString)
+            let userId = 9104L
+            let! _ = seedUser conn userId "stats_user_9104"
+
+            let user = Tg.user(id = userId, username = "stats_user_9104", firstName = "NoCoupons")
+            do! fixture.SetChatMemberStatus(user.Id, "member")
+            let! resp = fixture.SendUpdate(Tg.dmMessage("/stats", user))
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode)
+
+            let! calls = fixture.GetFakeCalls("sendMessage")
+
+            Assert.True(findCallWithText calls userId "Утилизация: —",
+                "Expected dash for user with no coupons at all")
+            Assert.True(findCallWithText calls userId "Сейчас активны: 0",
+                "Expected zero active coupons")
+        }


### PR DESCRIPTION
## Summary

- Adds outcome-based personal stats to `/stats`: used/expired/active/voided counts for coupons the user *added*, plus utilization rate (used ÷ (used + expired))
- Adds global community stats section: total added, used, expired, and community-wide utilization rate
- No DB migration needed — reads existing `coupon` table columns

Closes #294 (product agent analysis: users anxious about coupon "black hole", want visibility into their contributions)

## Test plan

- [ ] 5 new E2E tests in `StatsTests.fs` covering: personal breakdown with 50% utilization, global section, 100% utilization, dash when no terminal coupons, zero-coupons user
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)