### PR TITLE
fix: teach product agent to detect transparency gaps and admin info-sharing

### DIFF
--- a/.github/prompts/product.md
+++ b/.github/prompts/product.md
@@ -35,6 +35,16 @@ Flag anything notable:
 
 **Chat messages are critical.** The report includes recent message text from the community chat. Read every message carefully — users discuss real bugs and feature gaps there. Look for conversation threads (Reply To column) to understand context.
 
+**Known community members** (treat their messages with elevated weight and context):
+- Hash `9983047c` — technical admin/owner. Has direct database access and shares system stats manually in chat. When they post statistics or internal data, assume it is accurate.
+- Hash `42b77ec2` — non-technical admin. Community moderator; their messages reflect user perspective, not technical knowledge.
+
+**Specific patterns to identify in chat:**
+- **Technical admin manually shares stats or system info**: If `9983047c` posts statistics, tables, or internal data in chat that regular users cannot access themselves, this is a bot transparency gap — that information should be surfaced by the bot autonomously. Flag as a feature request.
+- **Workaround signals**: Users saying "I started doing X to deal with Y" — the Y is an unmet need even if the user sounds satisfied with their workaround.
+- **Conditional trust**: "I started trusting the bot after [someone explained X]" means the *next* user will not have that context unless the bot provides it. Flag the underlying information gap.
+- **Implicit needs**: Users rarely request features directly. Anxiety or confusion about the same aspect across multiple users is convergent evidence — apply the decision framework to inferred needs, not just explicit requests. Positive overall sentiment does not cancel out an underlying unmet need.
+
 ## Feedback Triage
 
 Check for unprocessed feedback issues:


### PR DESCRIPTION
## Summary

- Adds guidance for the technical admin chat hash (`9983047c`) and non-technical admin (`42b77ec2`) so the product agent can weight their messages appropriately
- Instructs the agent to treat technical admin manually sharing stats/data in chat as a bot transparency gap (feature request signal)
- Adds patterns for: workaround signals, conditional trust, and implicit needs inferred from user anxiety — not just explicit feature requests

Root cause of the miss: the agent saw the 97% utilization stat posted by the technical admin in chat and classified it as "positive signal", not recognising that information accessible only via manual admin post should be surfaced by the bot itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)